### PR TITLE
Feature: group관련 mock data, api, tanstack-query 생성 및 storybook 리팩터링

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import { withRouter } from '../utils/withRouter';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
@@ -20,3 +22,4 @@ export const parameters = {
     ],
   },
 };
+export const decorators = [(Story) => withRouter(<Story />)];

--- a/api/Detail/index.ts
+++ b/api/Detail/index.ts
@@ -1,0 +1,50 @@
+import api from '..';
+
+export interface DetailInfo {
+  userName: string;
+  groundsDate: string;
+  payment: number;
+  grounds: string;
+  paymentType: string;
+}
+
+export type DataWithEventId<T = null> = T & {
+  eventId: string;
+};
+
+export type DetailWithEventId = DataWithEventId<DetailInfo>;
+
+export type DetailStatusWithEventId = DataWithEventId<Pick<DetailInfo, 'paymentType'>>;
+
+export const createDetail = async (detailInfo: DetailInfo) => {
+  const { data } = await api.post('/api/event/penalty', detailInfo);
+  return data;
+};
+
+export const getOneOfDetail = async (eventId: string) => {
+  const { data } = await api.get(`api/event/penalty/${eventId}`);
+  return data;
+};
+
+/** 아직 미완성 */
+export const getDetailList = async () => {
+  const { data } = await api.get(`api/event/penalty/`);
+  return data;
+};
+
+export const updateDetail = async (info: DetailWithEventId) => {
+  const { eventId, ...detailInfo } = info;
+  const { data } = await api.post(`/api/event/penalty/${eventId}`, detailInfo);
+  return data;
+};
+
+export const updateDetailStatus = async (info: DetailStatusWithEventId) => {
+  const { eventId, paymentType } = info;
+  const { data } = await api.patch(`/api/event/penalty/${eventId}`, paymentType);
+  return data;
+};
+
+export const deleteDetail = async (eventId: string) => {
+  const { data } = await api.put(`/api/event/penalty/${eventId}`);
+  return data;
+};

--- a/api/Group/index.ts
+++ b/api/Group/index.ts
@@ -1,0 +1,97 @@
+import { GroupColor } from '@/constants';
+import api from '..';
+
+export interface GroupInfo {
+  title: string;
+  //   type: GroupType;
+  type: string;
+  coverColor: GroupColor;
+}
+
+export interface GroupId {
+  groupId: string;
+}
+
+export interface GroupNickname {
+  nickname: string;
+}
+
+export interface ServerResponse<T> {
+  message: string;
+  content: T;
+}
+
+export interface GroupDetail {
+  title: string;
+  adminNickname: string;
+  createDate: string;
+  updateDate: string;
+  coverColor: string;
+  groupType: string;
+}
+
+export interface ParticipantList {
+  adminId: string;
+  adminNickname: string;
+  nicknameList: string[];
+}
+
+export interface CoverGroupInfo {
+  title: string;
+  coverColor: GroupColor;
+  admin: string;
+}
+
+export const createGroup = async (newGroupInfo: GroupInfo): Promise<ServerResponse<GroupId>> => {
+  const { data } = await api.post('/api/group', newGroupInfo);
+  return data;
+};
+
+export const getGroupDetail = async (groupId: string): Promise<ServerResponse<GroupDetail>> => {
+  const { data } = await api.get(`/api/group/${groupId}`);
+  return data;
+};
+
+export const getGroupList = async (): Promise<ServerResponse<CoverGroupInfo[]>> => {
+  const { data } = await api.get(`/api/groupList`);
+  return data;
+};
+
+export const getParticipantList = async (groupId: string): Promise<ServerResponse<ParticipantList>> => {
+  const { data } = await api.get(`/api/group/${groupId}/participant`);
+  return data;
+};
+
+export const updateGroup = async (updateGroupInfo: GroupInfo & GroupId): Promise<ServerResponse<GroupId>> => {
+  const { groupId, ...groupInfo } = updateGroupInfo;
+  const { data } = await api.put(`/api/group/${groupId}`, groupInfo);
+  return data;
+};
+
+export const deleteGroup = async (groupId: string): Promise<ServerResponse<null>> => {
+  const { data } = await api.delete(`/api/group/${groupId}`);
+  return data;
+};
+
+export const joinGroup = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+  const { nickname, groupId } = info;
+  const { data } = await api.post(`/api/group/${groupId}/participant`, { nickname });
+  return data;
+};
+
+export const changeAdmin = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+  const { nickname, groupId } = info;
+  const { data } = await api.patch(`/api/group/admin/${groupId}`, { nickname });
+  return data;
+};
+
+export const withdrawalGroup = async (groupId: string): Promise<ServerResponse<null>> => {
+  const { data } = await api.delete(`/api/group/${groupId}`);
+  return data;
+};
+
+export const changeNickname = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+  const { nickname, groupId } = info;
+  const { data } = await api.patch(`/api/participant/${groupId}`, { nickname });
+  return data;
+};

--- a/api/Group/index.ts
+++ b/api/Group/index.ts
@@ -1,9 +1,9 @@
 import { GroupColor } from '@/constants';
+import { ServerResponse } from '@/types';
 import api from '..';
 
 export interface GroupInfo {
   title: string;
-  //   type: GroupType;
   type: string;
   coverColor: GroupColor;
 }
@@ -14,11 +14,6 @@ export interface GroupId {
 
 export interface GroupNickname {
   nickname: string;
-}
-
-export interface ServerResponse<T> {
-  message: string;
-  content: T;
 }
 
 export interface GroupDetail {
@@ -68,29 +63,29 @@ export const updateGroup = async (updateGroupInfo: GroupInfo & GroupId): Promise
   return data;
 };
 
-export const deleteGroup = async (groupId: string): Promise<ServerResponse<null>> => {
+export const deleteGroup = async (groupId: string): Promise<ServerResponse> => {
   const { data } = await api.delete(`/api/group/${groupId}`);
   return data;
 };
 
-export const joinGroup = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+export const joinGroup = async (info: GroupNickname & GroupId): Promise<ServerResponse> => {
   const { nickname, groupId } = info;
   const { data } = await api.post(`/api/group/${groupId}/participant`, { nickname });
   return data;
 };
 
-export const changeAdmin = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+export const changeAdmin = async (info: GroupNickname & GroupId): Promise<ServerResponse> => {
   const { nickname, groupId } = info;
   const { data } = await api.patch(`/api/group/admin/${groupId}`, { nickname });
   return data;
 };
 
-export const withdrawalGroup = async (groupId: string): Promise<ServerResponse<null>> => {
+export const withdrawalGroup = async (groupId: string): Promise<ServerResponse> => {
   const { data } = await api.delete(`/api/group/${groupId}`);
   return data;
 };
 
-export const changeNickname = async (info: GroupNickname & GroupId): Promise<ServerResponse<null>> => {
+export const changeNickname = async (info: GroupNickname & GroupId): Promise<ServerResponse> => {
   const { nickname, groupId } = info;
   const { data } = await api.patch(`/api/participant/${groupId}`, { nickname });
   return data;

--- a/common/Modal/styles.ts
+++ b/common/Modal/styles.ts
@@ -36,7 +36,7 @@ export const ModalHeader = styled.div<{ align: 'center' | 'start' }>`
   ${({ theme }) => theme.font.headline};
   width: 100%;
   text-align: ${({ align }) => align === 'center' && 'center'};
-  margin-bottom: 22px;
+  margin-bottom: 20px;
 `;
 
 export const CloseIcon = styled.div`

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,12 +1,12 @@
 export type GroupColor = '#f86565' | '#f89a65' | '#f8e065' | '#658ef8' | '#9465f8';
-// export type GroupColor = keyof Theme['cover'];
+export type GroupType = '스터디' | '학교, 교내/외 모임' | '회사, 사내 모임' | '취미, 동호회 모임' | '친구, 사모임' | '프로젝트' | '기타' | '';
 
 export const PLACEHOLDER = {
   NAME: '모임에서 사용할 이름을 입력해 주세요.',
   GROUP: '이름을 입력해 주세요.',
 };
 
-export const DROPDOWN_LIST = [
+export const DROPDOWN_LIST: { title: GroupType }[] = [
   { title: '스터디' },
   { title: '학교, 교내/외 모임' },
   { title: '회사, 사내 모임' },

--- a/hooks/useCheckInit.tsx
+++ b/hooks/useCheckInit.tsx
@@ -1,0 +1,15 @@
+import React, { useEffect, useState } from 'react';
+
+export const useCheckInit = (groupName: string, myName: string) => {
+  const [isInit, setIsInit] = useState({
+    groupName: true,
+    myName: true,
+  });
+
+  useEffect(() => {
+    if (groupName !== '' && isInit.groupName === true) setIsInit((prev) => ({ ...prev, groupName: false }));
+    if (myName !== '' && isInit.myName === true) setIsInit((prev) => ({ ...prev, myName: false }));
+  }, [groupName, myName]);
+
+  return [isInit.groupName, isInit.myName];
+};

--- a/mocks/handler.ts
+++ b/mocks/handler.ts
@@ -2,19 +2,25 @@ import { BASE_URL } from './../api/index';
 import { rest } from 'msw';
 
 const groupList = [
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', type: '스터디' },
+  { title: '전국 노래 자랑', admin: '윤하나둘셋넷', coverColor: '#f86565', id: '1' },
+  { title: '전국 노래 자랑', admin: '윤하나', coverColor: '#f86565', id: '2' },
+  { title: '전국 노래 자랑', admin: '윤둘', coverColor: '#f86565', id: '3' },
+  { title: '전국 노래 자랑', admin: '윤셋', coverColor: '#f86565', id: '4' },
+  { title: '전국 노래 자랑', admin: '윤넷', coverColor: '#f86565', id: '5' },
+  { title: '전국 노래 자랑', admin: '윤하나둘', coverColor: '#f86565', id: '6' },
+  { title: '전국 노래 자랑', admin: '윤하나셋넷', coverColor: '#f86565', id: '7' },
+  { title: '전국 노래 자랑', admin: '윤둘셋넷', coverColor: '#f86565', id: '8' },
+  { title: '전국 노래 자랑', admin: '윤하나둘넷', coverColor: '#f86565', id: '9' },
 ];
 
 const getGroupList: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
-  return res(ctx.status(200), ctx.json(groupList));
+  return res(
+    ctx.status(200),
+    ctx.json({
+      message: 'success',
+      content: groupList,
+    }),
+  );
 };
 
 const getGroupDetail: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
@@ -37,7 +43,16 @@ const getGroupDetail: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
 };
 
 const getGroupParticipant: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
-  return res(ctx.json({ message: '모임 참가자 리스트가 정상적으로 조회되었습니다.', content: {} }));
+  return res(
+    ctx.json({
+      message: '모임 참가자 리스트가 정상적으로 조회되었습니다.',
+      content: {
+        adminId: '125hlkfd',
+        adminNickname: '윤하나둘셋넷',
+        nicknameList: ['윤하나둘셋넷', '윤하나', '윤둘', '윤셋', '윤넷', '윤하나둘', '윤하나셋넷', '윤둘셋넷', '윤하나둘넷'],
+      },
+    }),
+  );
 };
 
 const createGroup: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
@@ -48,7 +63,7 @@ const createGroup: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
     ctx.json({
       message: '모임이 성공적으로 생성되었습니다.',
       content: {
-        group_id: 'fdsa',
+        group_id: '10',
       },
     }),
   );
@@ -58,11 +73,51 @@ const modifyGroup: Parameters<typeof rest.put>[1] = (req, res, ctx) => {
   return res(ctx.status(201));
 };
 
-const deleteGroup: Parameters<typeof rest.put>[1] = (req, res, ctx) => {
+const deleteGroup: Parameters<typeof rest.delete>[1] = (req, res, ctx) => {
   return res(
     ctx.status(200),
     ctx.json({
       message: '모임이 성공적으로 삭제되었습니다.',
+      content: null,
+    }),
+  );
+};
+
+const joinGroup: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
+  return res(
+    ctx.status(201),
+    ctx.json({
+      message: '모임에 성공적으로 참가되었습니다.',
+      content: null,
+    }),
+  );
+};
+
+const changeAdmin: Parameters<typeof rest.patch>[1] = async (req, res, ctx) => {
+  return res(
+    ctx.status(201),
+    ctx.json({
+      message: '관리자가 성공적으로 변경되었습니다.',
+      content: null,
+    }),
+  );
+};
+
+const withdrawalGroup: Parameters<typeof rest.delete>[1] = (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      message: '성공적으로 모임에서 탈퇴되었습니다.',
+      content: null,
+    }),
+  );
+};
+
+const changeNickname: Parameters<typeof rest.patch>[1] = async (req, res, ctx) => {
+  return res(
+    ctx.status(201),
+    ctx.json({
+      message: '성공적으로 닉네임이 수정되었습니다.',
       content: null,
     }),
   );
@@ -73,6 +128,10 @@ export const handler = [
   rest.get('/api/group/1', getGroupDetail),
   rest.get('/api/group/1/participant', getGroupParticipant),
   rest.post('/api/group', createGroup),
+  rest.post('/api/group/1/participant', joinGroup),
   rest.put('/api/group/1', modifyGroup),
+  rest.patch('/api/group/admin/1', changeAdmin),
+  rest.patch('/api/participant/1', changeNickname),
   rest.delete('/api/group/1', deleteGroup),
+  rest.delete('/api/group/1', withdrawalGroup),
 ];

--- a/pages/FineBook/components/DetailFine/components/FineBookModal/index.tsx
+++ b/pages/FineBook/components/DetailFine/components/FineBookModal/index.tsx
@@ -5,41 +5,28 @@ import { Label } from '@/common/Label';
 import Modal from '@/common/Modal';
 import { DropBox } from '@/pages/Home/components/Modal/DropBox';
 import * as Style from './styles';
+import { SYSTEM } from '@/assets/icons/System';
 
 interface ModalProps {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
+  type?: 'update' | 'create';
 }
 
-export const FineBookModal = ({ open, setOpen }: ModalProps) => {
+export const FineBookModal = ({ open, setOpen, type = 'create' }: ModalProps) => {
   const [member, setMember] = useState('');
   const [reason, setReason] = useState('');
 
   const [fine, setFine] = useState('');
 
-  const isSuitableKey = (key: string): boolean => {
-    switch (key) {
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':
-      case '8':
-      case '9':
-      case '0':
-      case 'Backspace':
-      case 'Enter':
-      case 'Tab':
-        return true;
-      default:
-        return false;
-    }
+  const isAllowedKey = (key: string): boolean => {
+    const allowedKey = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'Backspace', 'Enter', 'Tab'];
+    if (allowedKey.includes(key)) return true;
+    return false;
   };
 
   const onChangeFine = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (isSuitableKey(e.key))
+    if (isAllowedKey(e.key))
       setFine((prev) => {
         if (!isNaN(Number(e.key))) return prev + e.key;
         if (e.key === 'Backspace') return prev.slice(0, -1);
@@ -63,8 +50,8 @@ export const FineBookModal = ({ open, setOpen }: ModalProps) => {
   const status = [{ title: '미납' }, { title: '완납' }, { title: '확인 필요' }];
 
   return (
-    <Modal.Frame width="448px" height="412px" isOpen={open} onClick={() => setOpen(false)}>
-      <Modal.Header onClick={() => setOpen(false)}>상세 내역 수정</Modal.Header>
+    <Modal.Frame width="448px" height={type === 'create' ? '466px' : '412px'} isOpen={open} onClick={() => setOpen(false)}>
+      <Modal.Header onClick={() => setOpen(false)}>{type === 'create' ? '내역 추가하기' : '상세 내역 수정'}</Modal.Header>
       <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
         <Style.Row>
           <Label title="팀원" width="32px">
@@ -92,9 +79,11 @@ export const FineBookModal = ({ open, setOpen }: ModalProps) => {
           <Button color="black" width="100%" height="42px">
             저장하기
           </Button>
-          {/* <Button color="white" width="100%" height="42px" leftIcon={SYSTEM.PLUS_GRAY}>
-            계속해서 추가하기
-          </Button> */}
+          {type === 'create' && (
+            <Button color="white" width="100%" height="42px" leftIcon={SYSTEM.PLUS_GRAY}>
+              계속해서 추가하기
+            </Button>
+          )}
         </Modal.Footer>
       </div>
     </Modal.Frame>

--- a/pages/FineBook/components/DetailFine/components/InviteModal/index.stories.tsx
+++ b/pages/FineBook/components/DetailFine/components/InviteModal/index.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { InviteModal } from '.';
-import { withRouter } from '@/utils/withRouter';
 
 export default {
   title: 'Component/Modal/InviteModal',
   component: InviteModal,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof InviteModal>;
 
 const Template: ComponentStory<typeof InviteModal> = (args) => <InviteModal {...args} />;

--- a/pages/FineBook/components/DetailFine/components/InviteModal/index.tsx
+++ b/pages/FineBook/components/DetailFine/components/InviteModal/index.tsx
@@ -19,7 +19,7 @@ export const InviteModal: FC<ModalProps> = ({ isOpen, onClick }) => {
       </Modal.Body>
       <div style={{ height: '12px' }} />
       <Modal.Footer>
-        <Button color="primary" width="100%" leftIcon={SYSTEM.LINK}>
+        <Button color="primary" width="100%" leftIcon={SYSTEM.LINK} height="42px">
           초대링크 복사하기
         </Button>
       </Modal.Footer>

--- a/pages/FineBook/components/DetailFine/components/InviteModal/styles.ts
+++ b/pages/FineBook/components/DetailFine/components/InviteModal/styles.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Title = styled.div`
-  margin-bottom: 32px;
+  /* margin-bottom: 32px; */
   text-align: center;
 `;
 

--- a/pages/Home/components/Card/AddCard/index.stories.tsx
+++ b/pages/Home/components/Card/AddCard/index.stories.tsx
@@ -5,7 +5,6 @@ import { withRouter } from '../../../../../utils/withRouter';
 export default {
   title: 'Component/Card/AddCard',
   component: AddCard,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof AddCard>;
 
 const Template: ComponentStory<typeof AddCard> = (arg) => <AddCard {...arg} />;

--- a/pages/Home/components/Card/GroupCard/index.stories.tsx
+++ b/pages/Home/components/Card/GroupCard/index.stories.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { GroupCard } from '.';
-import { withRouter } from '../../../../../utils/withRouter';
+
 export default {
   title: 'Component/Card/GroupCard',
   component: GroupCard,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof GroupCard>;
 
 const Template: ComponentStory<typeof GroupCard> = (arg) => <GroupCard {...arg} />;
@@ -14,6 +12,6 @@ export const GroupCardComponent = Template.bind({});
 
 GroupCardComponent.args = {
   title: '전국 대한 산악회',
-  color: '#f86565',
+  coverColor: '#f86565',
   admin: '하이하이하이염',
 };

--- a/pages/Home/components/Card/GroupCard/index.tsx
+++ b/pages/Home/components/Card/GroupCard/index.tsx
@@ -1,15 +1,15 @@
 import { Card } from '..';
-import { GroupInfo } from '../../CardList';
 import * as Style from './style';
-import { USER } from '../../../../../assets/icons/User';
+import { USER } from '@/assets/icons/User';
 import { useNavigate } from 'react-router-dom';
+import { CoverGroupInfo } from '@/api/Group';
 
-export const GroupCard = ({ title, color, admin }: GroupInfo) => {
+export const GroupCard = ({ title, coverColor, admin }: CoverGroupInfo) => {
   const navigate = useNavigate();
 
   return (
     <Card onClick={() => navigate(`/group/1`)}>
-      <Style.GroupColor color={color} />
+      <Style.GroupColor color={coverColor} />
       <Style.GroupInfo>
         <Style.GroupTitle>{title}</Style.GroupTitle>
         <Style.GroupPeople>

--- a/pages/Home/components/CardList/index.tsx
+++ b/pages/Home/components/CardList/index.tsx
@@ -3,27 +3,12 @@ import { AddCard } from '../Card/AddCard';
 import { GroupCard } from '../Card/GroupCard';
 import { CreateGroupModal } from '../Modal/CreateGroupModal';
 import * as Style from './style';
-import React from 'react';
-import { GroupColor } from '../../../../constants';
-
-export interface GroupInfo {
-  title: string;
-  color: GroupColor;
-  admin: string;
-}
+import { useGroupList } from '@/queries/Group/';
 
 export const CardList = () => {
   const [open, setOpen] = useState(false);
 
-  const groupList: GroupInfo[] = [
-    { title: '전국 대한 산악회1', color: '#f86565', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회2', color: '#f89a65', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회3', color: '#f8e065', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회4', color: '#658ef8', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회5', color: '#9465f8', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회6', color: '#f86565', admin: '안녕하세요안녕하세요안녕하세요' },
-    { title: '전국 대한 산악회7', color: '#658ef8', admin: '안녕하세요안녕하세요안녕하세요' },
-  ];
+  const { data } = useGroupList();
 
   const dealWithModal = () => {
     setOpen((prev) => !prev);
@@ -33,7 +18,7 @@ export const CardList = () => {
     <>
       <Style.CardList>
         <AddCard onClick={dealWithModal} />
-        {groupList.map((group) => {
+        {data?.content.map((group) => {
           return <GroupCard {...group} key={group.title} />;
         })}
       </Style.CardList>

--- a/pages/Home/components/Header/index.stories.tsx
+++ b/pages/Home/components/Header/index.stories.tsx
@@ -1,11 +1,9 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Header } from '.';
-import { withRouter } from '@/utils/withRouter';
 
 export default {
   title: 'Component/Header',
   component: Header,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof Header>;
 
 const Template: ComponentStory<typeof Header> = () => <Header />;

--- a/pages/Home/components/Modal/AdminModal/index.stories.tsx
+++ b/pages/Home/components/Modal/AdminModal/index.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { AdminModal } from '.';
-import { withRouter } from '@/utils/withRouter';
 
 export default {
   title: 'Component/Modal/AdminModal',
   component: AdminModal,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof AdminModal>;
 
 const Template: ComponentStory<typeof AdminModal> = (args) => <AdminModal {...args} />;

--- a/pages/Home/components/Modal/AdminModal/index.tsx
+++ b/pages/Home/components/Modal/AdminModal/index.tsx
@@ -10,6 +10,10 @@ import { QuitGroup } from '../QuitGroup';
 import * as Style from './style';
 import { COLORS, DROPDOWN_LIST, GroupColor } from '@/constants';
 import { ModalProps } from '../CreateGroupModal';
+import { useCheckInit } from '@/hooks/useCheckInit';
+import { useUpdateGroup } from '@/queries/Group';
+import { useParams } from 'react-router-dom';
+import { GroupId } from '@/api/Group';
 
 export const AdminModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
   const [groupName, setGroupName] = useState('');
@@ -17,15 +21,16 @@ export const AdminModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
   const [type, setType] = useState('');
   const [color, setColor] = useState<GroupColor>('#f86565');
 
-  const [isInit, setIsInit] = useState({
-    groupName: true,
-    myName: true,
-  });
+  const [groupCheck, nameCheck] = useCheckInit(groupName, myName);
 
-  useEffect(() => {
-    if (groupName !== '' && isInit.groupName === true) setIsInit((prev) => ({ ...prev, groupName: false }));
-    if (myName !== '' && isInit.myName === true) setIsInit((prev) => ({ ...prev, myName: false }));
-  }, [groupName, myName]);
+  const params = useParams();
+  console.log(params);
+
+  const update = useUpdateGroup();
+
+  const updateGroupInfo = () => {
+    // update.mutate({ title: groupName, type, coverColor: color, groupId: params.groupId });
+  };
 
   const isValidForm = (): boolean => {
     if (!isValid(groupName)) return false;
@@ -45,10 +50,10 @@ export const AdminModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
           <Style.SubTitle>사용자 설정</Style.SubTitle>
           <div style={{ width: '100%', borderLeft: `2px solid ${theme.colors.neutral_400_b}`, paddingLeft: '16px' }}>
             <Label title="모임 이름" flexDirection="column">
-              <Input value={groupName} isValid={isInit.groupName || isValid(groupName)} onChange={setGroupName} maxLength={15} />
+              <Input value={groupName} isValid={groupCheck || isValid(groupName)} onChange={setGroupName} maxLength={15} />
             </Label>
             <Label title="내 이름" flexDirection="column">
-              <Input value={myName} isValid={isInit.myName || isValid(myName)} onChange={setMyName} maxLength={15} />
+              <Input value={myName} isValid={nameCheck || isValid(myName)} onChange={setMyName} maxLength={15} />
             </Label>
             <Label title="모임 유형" flexDirection="column">
               <DropBox dropDownList={DROPDOWN_LIST} type={type} setType={setType} />

--- a/pages/Home/components/Modal/CreateGroupModal/index.stories.tsx
+++ b/pages/Home/components/Modal/CreateGroupModal/index.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { CreateGroupModal } from '.';
-import { withRouter } from '@/utils/withRouter';
 
 export default {
   title: 'Component/Modal/CreateGroupModal',
   component: CreateGroupModal,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof CreateGroupModal>;
 
 const Template: ComponentStory<typeof CreateGroupModal> = (args) => <CreateGroupModal {...args} />;

--- a/pages/Home/components/Modal/CreateGroupModal/index.tsx
+++ b/pages/Home/components/Modal/CreateGroupModal/index.tsx
@@ -64,7 +64,7 @@ export const CreateGroupModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
         </Label>
         <div style={{ position: 'relative' }}>
           <Label title="모임 유형">
-            <DropBox dropDownList={DROPDOWN_LIST} type={type} setType={setType} />
+            <DropBox dropDownList={DROPDOWN_LIST} type={type} setType={setType} color="gray" />
           </Label>
         </div>
         <Label title="커버 색상">

--- a/pages/Home/components/Modal/CreateGroupModal/index.tsx
+++ b/pages/Home/components/Modal/CreateGroupModal/index.tsx
@@ -6,20 +6,13 @@ import { GroupColorList } from '../GroupColorList';
 import { Input, Label } from '@/common';
 import { DropBox } from '../DropBox';
 import { isValid } from '@/utils/validation';
-import { COLORS, DROPDOWN_LIST, PLACEHOLDER } from '@/constants';
+import { COLORS, DROPDOWN_LIST, GroupType, PLACEHOLDER } from '@/constants';
 import { GroupColor } from '@/constants';
-import { useCreateGroup } from '@/queries/Group/useCreateGroup';
+import { useCreateGroup } from '@/queries/Group';
 
 export interface ModalProps {
   isOpen: boolean;
   setIsOpen: () => void;
-}
-
-export interface FormData {
-  groupName: string;
-  myName: string;
-  type: string;
-  color: GroupColor;
 }
 
 export const CreateGroupModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
@@ -27,20 +20,19 @@ export const CreateGroupModal: FC<ModalProps> = ({ isOpen, setIsOpen }) => {
   const [myName, setMyName] = useState('');
   const [type, setType] = useState('');
   const [color, setColor] = useState<GroupColor>('#f86565');
-
   const [isInit, setIsInit] = useState({
     groupName: true,
     myName: true,
   });
 
-  const { mutate } = useCreateGroup();
-
-  const createGroup = () => mutate({ groupName, myName, type, color });
-
   useEffect(() => {
     if (groupName !== '' && isInit.groupName === true) setIsInit((prev) => ({ ...prev, groupName: false }));
     if (myName !== '' && isInit.myName === true) setIsInit((prev) => ({ ...prev, myName: false }));
   }, [groupName, myName]);
+
+  const { mutate } = useCreateGroup();
+
+  const createGroup = () => mutate({ title: groupName, type, coverColor: color });
 
   const isValidForm = (): boolean => {
     if (!isValid(groupName)) return false;

--- a/pages/Home/components/Modal/CreateGroupModal/style.ts
+++ b/pages/Home/components/Modal/CreateGroupModal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Title = styled.div`
-  margin-bottom: 24px;
+  /* margin-bottom: 24px; */
 `;
 
 export const Input = styled.input<{ isValid: boolean }>`

--- a/pages/Home/components/Modal/DropBox/styles.ts
+++ b/pages/Home/components/Modal/DropBox/styles.ts
@@ -11,7 +11,7 @@ export const DropDownBox = styled.div<{ boxWidth: string; color: DropBoxColor }>
   padding: 4px 12px;
   margin-right: 0;
   background: ${({ theme, color }) => (color === 'white' ? 'transparent' : color === 'gray' ? theme.colors.secondary_200 : theme.colors.neutral_200_b)};
-  border: 2px solid ${({ theme, color }) => (color === 'white' ? theme.colors.secondary_800 : color === 'disabled' && theme.colors.neutral_400_b)};
+  border: 2px solid ${({ theme, color }) => (color === 'white' ? theme.colors.secondary_800 : color === 'disabled' ? theme.colors.neutral_400_b : theme.colors.secondary_200)};
   border-radius: 4px;
 `;
 

--- a/pages/Home/components/Modal/InvitationModal/index.stories.tsx
+++ b/pages/Home/components/Modal/InvitationModal/index.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { InvitationModal } from '.';
-import { withRouter } from '../../../../../utils/withRouter';
 
 export default {
   title: 'Component/Modal/InvitationModal',

--- a/pages/Home/components/Modal/InvitationModal/index.stories.tsx
+++ b/pages/Home/components/Modal/InvitationModal/index.stories.tsx
@@ -6,7 +6,6 @@ import { withRouter } from '../../../../../utils/withRouter';
 export default {
   title: 'Component/Modal/InvitationModal',
   component: InvitationModal,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof InvitationModal>;
 
 const Template: ComponentStory<typeof InvitationModal> = (args) => <InvitationModal {...args} />;

--- a/pages/Home/components/Modal/InvitationModal/index.tsx
+++ b/pages/Home/components/Modal/InvitationModal/index.tsx
@@ -26,7 +26,7 @@ export const InvitationModal: FC<ModalProps> = ({ isOpen, onClick }) => {
         </Label>
       </Modal.Body>
       <Modal.Footer>
-        <Button color={myName !== '' ? 'primary' : 'disabled'} width="100%">
+        <Button color={myName !== '' ? 'primary' : 'disabled'} width="100%" height="42px">
           입장하기
         </Button>
       </Modal.Footer>

--- a/pages/Home/components/Modal/InvitationModal/styles.ts
+++ b/pages/Home/components/Modal/InvitationModal/styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
 export const Title = styled.div`
-  margin-bottom: 20px;
+  /* margin-bottom: 20px; */
   text-align: center;
 `;

--- a/pages/Home/components/Modal/LoginModal/index.stories.tsx
+++ b/pages/Home/components/Modal/LoginModal/index.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { LoginModal } from '.';
-import { withRouter } from '@/utils/withRouter';
 
 export default {
   title: 'Component/Modal/LoginModal',
   component: LoginModal,
-  decorators: [(Story) => withRouter(<Story />)],
 } as ComponentMeta<typeof LoginModal>;
 
 const Template: ComponentStory<typeof LoginModal> = (args) => <LoginModal {...args} />;

--- a/pages/Home/components/Modal/LoginModal/styles.ts
+++ b/pages/Home/components/Modal/LoginModal/styles.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
 export const GuidePhrase = styled.p`
-  margin-top: 22px;
+  /* margin-top: 22px; */
 `;
 
 export const LinkTo = styled(Link)`

--- a/queries/Detail/useCreateDetail.ts
+++ b/queries/Detail/useCreateDetail.ts
@@ -1,0 +1,8 @@
+import { createDetail, DetailInfo } from '@/api/Detail';
+import { ServerResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useCreateDetail = () => {
+  return useMutation<ServerResponse<{ id: string }>, AxiosError, DetailInfo>(createDetail);
+};

--- a/queries/Detail/useDeleteDetail.ts
+++ b/queries/Detail/useDeleteDetail.ts
@@ -1,0 +1,8 @@
+import { createDetail, DataWithEventId, deleteDetail, DetailInfo } from '@/api/Detail';
+import { ServerResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useDeleteDetail = () => {
+  return useMutation<ServerResponse<{ eventId: string }>, AxiosError, DataWithEventId>(deleteDetail);
+};

--- a/queries/Detail/useGetOneOfDetail.ts
+++ b/queries/Detail/useGetOneOfDetail.ts
@@ -1,0 +1,7 @@
+import { getOneOfDetail, DetailInfo } from '@/api/Detail';
+import { ServerResponse } from '@/types';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetOneOfDetail = (eventId: string) => {
+  return useQuery<ServerResponse<DetailInfo>>(['oneOfDetail', eventId], () => getOneOfDetail(eventId));
+};

--- a/queries/Detail/useUpdateDetail.ts
+++ b/queries/Detail/useUpdateDetail.ts
@@ -1,0 +1,8 @@
+import { DetailWithEventId, updateDetail, DetailInfo } from '@/api/Detail';
+import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+
+export const useUpdateDetail = () => {
+  return useMutation<ServerResponse<DetailInfo>, AxiosError, DetailWithEventId>(updateDetail);
+};

--- a/queries/Detail/useUpdateDetailStatus.ts
+++ b/queries/Detail/useUpdateDetailStatus.ts
@@ -1,0 +1,8 @@
+import { DetailInfo, DetailStatusWithEventId, updateDetailStatus } from '@/api/Detail';
+import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
+import { useMutation } from '@tanstack/react-query';
+
+export const useUpdateDetailStatus = () => {
+  return useMutation<ServerResponse<DetailInfo>, AxiosError, DetailStatusWithEventId>(updateDetailStatus);
+};

--- a/queries/Group/index.ts
+++ b/queries/Group/index.ts
@@ -1,0 +1,16 @@
+export { useUpdateGroup } from './useUpdateGroup';
+export { useParticipantList } from './useParticipantList';
+export { useJoinGroup } from './useJoinGroup';
+export { useGroupList } from './useGroupList';
+export { useGroupDetail } from './useGroupDetail';
+export { useCreateGroup } from './useCreateGroup';
+export { useChangeNickname } from './useChangeNickname';
+export { useChangeAdmin } from './useChangeAdmin';
+export { useDeleteGroup } from './useDeleteGroup';
+export { useWithdrawalGroup } from './useWithdrawalGroup';
+
+import { ServerResponse } from '@/api/Group';
+
+export const message = {
+  onSuccess: (data: ServerResponse<any>) => console.log(data.message),
+};

--- a/queries/Group/index.ts
+++ b/queries/Group/index.ts
@@ -8,8 +8,7 @@ export { useChangeNickname } from './useChangeNickname';
 export { useChangeAdmin } from './useChangeAdmin';
 export { useDeleteGroup } from './useDeleteGroup';
 export { useWithdrawalGroup } from './useWithdrawalGroup';
-
-import { ServerResponse } from '@/api/Group';
+import { ServerResponse } from '@/types';
 
 export const message = {
   onSuccess: (data: ServerResponse<any>) => console.log(data.message),

--- a/queries/Group/useChangeAdmin.ts
+++ b/queries/Group/useChangeAdmin.ts
@@ -1,8 +1,9 @@
 import { message } from './index';
-import { changeAdmin, GroupId, GroupNickname, ServerResponse } from '@/api/Group';
+import { changeAdmin, GroupId, GroupNickname } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useChangeAdmin = () => {
-  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(changeAdmin, message);
+  return useMutation<ServerResponse, AxiosError, GroupNickname & GroupId>(changeAdmin, message);
 };

--- a/queries/Group/useChangeAdmin.ts
+++ b/queries/Group/useChangeAdmin.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { changeAdmin, GroupId, GroupNickname, ServerResponse } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useChangeAdmin = () => {
+  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(changeAdmin, message);
+};

--- a/queries/Group/useChangeNickname.ts
+++ b/queries/Group/useChangeNickname.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { changeNickname, GroupId, GroupNickname, ServerResponse } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useChangeNickname = () => {
+  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(changeNickname, message);
+};

--- a/queries/Group/useChangeNickname.ts
+++ b/queries/Group/useChangeNickname.ts
@@ -1,8 +1,9 @@
 import { message } from './index';
-import { changeNickname, GroupId, GroupNickname, ServerResponse } from '@/api/Group';
+import { changeNickname, GroupId, GroupNickname } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useChangeNickname = () => {
-  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(changeNickname, message);
+  return useMutation<ServerResponse, AxiosError, GroupNickname & GroupId>(changeNickname, message);
 };

--- a/queries/Group/useCreateGroup.ts
+++ b/queries/Group/useCreateGroup.ts
@@ -1,7 +1,8 @@
 import { message } from './index';
-import { GroupId, createGroup, deleteGroup, GroupInfo, ServerResponse, joinGroup, GroupNickname, withdrawalGroup, changeNickname, changeAdmin } from '@/api/Group';
+import { GroupId, createGroup, deleteGroup, GroupInfo, joinGroup, GroupNickname, withdrawalGroup, changeNickname, changeAdmin } from '@/api/Group';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useCreateGroup = () => {
   return useMutation<ServerResponse<GroupId>, AxiosError, GroupInfo>(createGroup, message);

--- a/queries/Group/useCreateGroup.ts
+++ b/queries/Group/useCreateGroup.ts
@@ -1,11 +1,8 @@
-import api from '@/api';
-import { FormData } from '@/pages/Home/components/Modal/CreateGroupModal';
-import { useMutation } from '@tanstack/react-query';
+import { message } from './index';
+import { GroupId, createGroup, deleteGroup, GroupInfo, ServerResponse, joinGroup, GroupNickname, withdrawalGroup, changeNickname, changeAdmin } from '@/api/Group';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 export const useCreateGroup = () => {
-  return useMutation({
-    mutationFn: (newGroupInfo: FormData) => {
-      return api.post('/api/group', newGroupInfo);
-    },
-  });
+  return useMutation<ServerResponse<GroupId>, AxiosError, GroupInfo>(createGroup, message);
 };

--- a/queries/Group/useDeleteGroup.ts
+++ b/queries/Group/useDeleteGroup.ts
@@ -1,8 +1,9 @@
 import { message } from './index';
-import { deleteGroup, ServerResponse } from '@/api/Group';
+import { deleteGroup } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useDeleteGroup = () => {
-  return useMutation<ServerResponse<null>, AxiosError, string>(deleteGroup, message);
+  return useMutation<ServerResponse, AxiosError, string>(deleteGroup, message);
 };

--- a/queries/Group/useDeleteGroup.ts
+++ b/queries/Group/useDeleteGroup.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { deleteGroup, ServerResponse } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useDeleteGroup = () => {
+  return useMutation<ServerResponse<null>, AxiosError, string>(deleteGroup, message);
+};

--- a/queries/Group/useGroupDetail.ts
+++ b/queries/Group/useGroupDetail.ts
@@ -1,0 +1,6 @@
+import { getGroupDetail } from '@/api/Group';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGroupDetail = (groupId: string) => {
+  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId));
+};

--- a/queries/Group/useGroupDetail.ts
+++ b/queries/Group/useGroupDetail.ts
@@ -1,6 +1,7 @@
-import { getGroupDetail } from '@/api/Group';
+import { getGroupDetail, GroupDetail } from '@/api/Group';
+import { ServerResponse } from '@/types';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGroupDetail = (groupId: string) => {
-  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId));
+  return useQuery<ServerResponse<GroupDetail>>(['groupDetail', groupId], () => getGroupDetail(groupId));
 };

--- a/queries/Group/useGroupList.ts
+++ b/queries/Group/useGroupList.ts
@@ -1,0 +1,6 @@
+import { getGroupList } from '@/api/Group';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGroupList = () => {
+  return useQuery(['groupList'], getGroupList);
+};

--- a/queries/Group/useJoinGroup.ts
+++ b/queries/Group/useJoinGroup.ts
@@ -1,8 +1,9 @@
 import { message } from './index';
-import { GroupId, GroupNickname, joinGroup, ServerResponse } from '@/api/Group';
+import { GroupId, GroupNickname, joinGroup } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useJoinGroup = () => {
-  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(joinGroup, message);
+  return useMutation<ServerResponse, AxiosError, GroupNickname & GroupId>(joinGroup, message);
 };

--- a/queries/Group/useJoinGroup.ts
+++ b/queries/Group/useJoinGroup.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { GroupId, GroupNickname, joinGroup, ServerResponse } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useJoinGroup = () => {
+  return useMutation<ServerResponse<null>, AxiosError, GroupNickname & GroupId>(joinGroup, message);
+};

--- a/queries/Group/useParticipantList.ts
+++ b/queries/Group/useParticipantList.ts
@@ -1,6 +1,7 @@
-import { getParticipantList } from '@/api/Group';
+import { getParticipantList, ParticipantList } from '@/api/Group';
+import { ServerResponse } from '@/types';
 import { useQuery } from '@tanstack/react-query';
 
 export const useParticipantList = (groupId: string) => {
-  return useQuery(['participantList', groupId], () => getParticipantList(groupId));
+  return useQuery<ServerResponse<ParticipantList>>(['participantList', groupId], () => getParticipantList(groupId));
 };

--- a/queries/Group/useParticipantList.ts
+++ b/queries/Group/useParticipantList.ts
@@ -1,0 +1,6 @@
+import { getParticipantList } from '@/api/Group';
+import { useQuery } from '@tanstack/react-query';
+
+export const useParticipantList = (groupId: string) => {
+  return useQuery(['participantList', groupId], () => getParticipantList(groupId));
+};

--- a/queries/Group/useUpdateGroup.ts
+++ b/queries/Group/useUpdateGroup.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { GroupId, GroupInfo, ServerResponse, updateGroup } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useUpdateGroup = () => {
+  return useMutation<ServerResponse<GroupId>, AxiosError, GroupInfo & GroupId>(updateGroup, message);
+};

--- a/queries/Group/useUpdateGroup.ts
+++ b/queries/Group/useUpdateGroup.ts
@@ -1,7 +1,8 @@
 import { message } from './index';
-import { GroupId, GroupInfo, ServerResponse, updateGroup } from '@/api/Group';
+import { GroupId, GroupInfo, updateGroup } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useUpdateGroup = () => {
   return useMutation<ServerResponse<GroupId>, AxiosError, GroupInfo & GroupId>(updateGroup, message);

--- a/queries/Group/useWithdrawalGroup.ts
+++ b/queries/Group/useWithdrawalGroup.ts
@@ -1,8 +1,9 @@
 import { message } from './index';
-import { ServerResponse, withdrawalGroup } from '@/api/Group';
+import { withdrawalGroup } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { ServerResponse } from '@/types';
 
 export const useWithdrawalGroup = () => {
-  return useMutation<ServerResponse<null>, AxiosError, string>(withdrawalGroup, message);
+  return useMutation<ServerResponse, AxiosError, string>(withdrawalGroup, message);
 };

--- a/queries/Group/useWithdrawalGroup.ts
+++ b/queries/Group/useWithdrawalGroup.ts
@@ -1,0 +1,8 @@
+import { message } from './index';
+import { ServerResponse, withdrawalGroup } from '@/api/Group';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useWithdrawalGroup = () => {
+  return useMutation<ServerResponse<null>, AxiosError, string>(withdrawalGroup, message);
+};

--- a/routes/Router.tsx
+++ b/routes/Router.tsx
@@ -10,7 +10,7 @@ const Router = () => {
         <Route path="/" element={<Home />} />
         <Route path="/login/oauth2/code/kakao" element={<KaKaoAuth />} />
         <Route path="/tos" element={<TOS />} />
-        <Route path="/group/:groupID/*" element={<GroupLayout />} />
+        <Route path="/group/:groupId/*" element={<GroupLayout />} />
       </Routes>
     </BrowserRouter>
   );

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,4 @@
+export interface ServerResponse<T = null> {
+  message: string;
+  content: T;
+}

--- a/utils/withRouter.tsx
+++ b/utils/withRouter.tsx
@@ -1,16 +1,21 @@
 import { Global, ThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import globalStyle from '../styles/GlobalStyle';
 import theme from '../styles/Theme';
 
 export const withRouter = (components: any) => {
+  const queryClient = new QueryClient();
+
   return (
     <MemoryRouter>
-      <ThemeProvider theme={theme}>
-        <Global styles={globalStyle} />
-        {components}
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <Global styles={globalStyle} />
+          {components}
+        </ThemeProvider>
+      </QueryClientProvider>
     </MemoryRouter>
   );
 };


### PR DESCRIPTION
### 실행
- Group
  - /mock/Group 안에 group 관련된 api 목록 생성 및 타입 선언
  - mock data에 현재 진행된 api 명세 추가
  - /queries/Group 안에 tanstack-query custom hooks 생성

<br/>

- Detail
  - /mock/Detail 안에 detail 관련된 api 목록 생성 및 타입 선언
  - mock data에 현재 진행된 api 명세 추가
  - /queries/Detail 안에 tanstack-query custom hooks 생성

<br/>

- ServerResponse
  - server에서 받는 response는 항상 아래와 같은 형태임
<img src='https://user-images.githubusercontent.com/95389265/224520978-6ab9bb91-4159-40d9-a864-a05893703a47.png' width='50%' />

  - `ServerResponse<서버에서 전달받는 Response 데이터 타입>` 으로 사용하면 됨
  - 받아오는 content가 null일 경우에는 `ServerResponse`만 사용하면 됨
  - content로 GroupId가 넘어올 때에는 `ServerResponse<GroupId>`와 같이 사용

<br/>

- Storybook 
  - 기존 모든 stories에서 router, provider, style 등을 decorator로 감싸줘야 하는 번거로움이 있었음
- 해결
  - **/.stories/preivew.js 파일에서 decorator로 감싸줘서 더이상 stories 각각에서 선언해줄 필요 없음**


### 논의 사항
- 위의 `interface ServerResponse` 및 서버에서 전달해주는 데이터의 타입을 선언해둘 파일 필요
- 어디에 몰아둘지 논의 필요 @Dae-une  
  -> types/index.ts로 위치 변경
