### PR TITLE
[fix] 모임 설정 모달 , 그룹 리스트 불러오기, 총무 권한 변경 수정

### DIFF
--- a/api/Group/index.ts
+++ b/api/Group/index.ts
@@ -41,7 +41,7 @@ export const joinGroup = async (info: GroupNickname & GroupId): Promise<ServerRe
 
 export const changeAdmin = async (info: GroupNickname & GroupId): Promise<ServerResponse> => {
   const { nickname, groupId } = info;
-  const { data } = await api.patch(`/api/group/admin/${groupId}`, { nickname });
+  const { data } = await api.patch(`/api/group/${groupId}/admin`, { nickname });
   return data;
 };
 

--- a/common/Modal/GroupSettingModal/AdminModal/index.tsx
+++ b/common/Modal/GroupSettingModal/AdminModal/index.tsx
@@ -101,12 +101,11 @@ export const AdminModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
               <Label title="커버 색상" flexDirection="column">
                 <GroupColorList value={coverColor} onChange={setCoverColor} />
               </Label>
-              <Label title="모임 탈퇴" flexDirection="column">
-                <Style.WithDrwal>
-                  <Style.GroupName>{groupData?.content.title}</Style.GroupName>
-                  <Style.QuitButton onClick={handleGroupWithdrawalModal}>탈퇴</Style.QuitButton>
-                </Style.WithDrwal>
-              </Label>
+              <Label title="모임 탈퇴" flexDirection="column" />
+              <Style.WithDrwal>
+                <Style.GroupName>{groupData?.content.title}</Style.GroupName>
+                <Style.QuitButton onClick={handleGroupWithdrawalModal}>탈퇴</Style.QuitButton>
+              </Style.WithDrwal>
               <Style.Flex>
                 <Style.DeleteButton onClick={handleGroupDeleteModal}>모임 삭제</Style.DeleteButton>
               </Style.Flex>

--- a/common/Modal/GroupSettingModal/UserModal/index.tsx
+++ b/common/Modal/GroupSettingModal/UserModal/index.tsx
@@ -56,12 +56,11 @@ export const UserModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
               <Label title="내 이름" flexDirection="column">
                 <Input value={myName} errorText={errorText} isValid={isValid(myName) && !isError} onChange={setMyName} maxLength={20} />
               </Label>
-              <Label title="모임 탈퇴" flexDirection="column">
-                <Style.WithDrwal>
-                  <Style.GroupName>{groupData?.content.title}</Style.GroupName>
-                  <Style.QuitButton onClick={handleGroupWithdrawalModal}>탈퇴</Style.QuitButton>
-                </Style.WithDrwal>
-              </Label>
+              <Label title="모임 탈퇴" flexDirection="column" />
+              <Style.WithDrwal>
+                <Style.GroupName>{groupData?.content.title}</Style.GroupName>
+                <Style.QuitButton onClick={handleGroupWithdrawalModal}>탈퇴</Style.QuitButton>
+              </Style.WithDrwal>
             </Style.InputContainer>
           </Style.Flex>
         </Modal.Body>

--- a/queries/Group/useGroupList.ts
+++ b/queries/Group/useGroupList.ts
@@ -9,7 +9,7 @@ import { getAccessToken } from '@/utils/acceessToken';
 export const useGroupList = () => {
   return useInfiniteQuery(['groupList'], ({ pageParam = 0 }) => getGroupList(pageParam), {
     getNextPageParam: (context) => {
-      return context.content?.next ? context.nextPage : undefined;
+      return context?.content?.next ? context.nextPage : undefined;
     },
     onError: (error) => {
       const { response } = error as unknown as AxiosError;


### PR DESCRIPTION
- 모임 설정 모달에서 탈퇴 버튼에 라벨이 붙어 있어 라벨과 버튼을 분리
- 모임 탈퇴 및 삭제 시 그룹 리스트 불러올 때 에러나는 부분 옵셔널 처리
- 총무 권한 변경 api 수정