### PR TITLE
[Fix] reTakeToken 상태 코트에 따른 분기 처리, 401이 아닌 에러 글로벌에서 처리

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,17 +4,31 @@ import theme from './styles/Theme';
 import Router from './routes/Router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
-import { Toast } from './common/Toast';
+import { Toast, ToastPopUp } from './common/Toast';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { AxiosError } from 'axios';
+import { TOAST_ERROR } from './constants/Toast';
 
 const App = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
       mutations: {
         retry: 2,
+        onError: (error) => {
+          const { response } = error as unknown as AxiosError;
+          if (response?.status !== 401) {
+            ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
+          }
+        },
       },
       queries: {
         retry: 2,
+        onError: (error) => {
+          const { response } = error as unknown as AxiosError;
+          if (response?.status !== 401) {
+            ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
+          }
+        },
       },
     },
   });

--- a/App.tsx
+++ b/App.tsx
@@ -7,9 +7,18 @@ import { RecoilRoot } from 'recoil';
 import { Toast } from './common/Toast';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const queryClient = new QueryClient();
-
 const App = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: 2,
+      },
+      queries: {
+        retry: 2,
+      },
+    },
+  });
+
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>

--- a/api/Auth/index.ts
+++ b/api/Auth/index.ts
@@ -5,7 +5,6 @@ import { setAccesToken } from '@/utils/acceessToken';
 
 export const kakaoSignUp = async (code: string): Promise<ServerResponse<SignUpResult>> => {
   const { data } = await api.post(`/login/kakao?code=${code}`);
-  setAccesToken(data.accessToken);
   return data;
 };
 
@@ -16,6 +15,6 @@ export const kakaoSignIn = async (code: string | null): Promise<ServerResponse<S
 
 export const reTakeToken = async (): Promise<ServerResponse> => {
   const { data } = await api.get('/login/reissueToken');
-  setAccesToken(data.accessToken);
+  setAccesToken(data.content.accessToken);
   return data;
 };

--- a/api/Auth/index.ts
+++ b/api/Auth/index.ts
@@ -1,7 +1,7 @@
 import { SignUpResult } from './../../types/auth.d';
 import { ServerResponse } from '@/types/serverResponse';
 import api from '..';
-import { removeAccessToken } from '@/utils/acceessToken';
+import { removeAccessToken, setAccesToken } from '@/utils/acceessToken';
 import { AxiosError } from 'axios';
 import { KAKAO_URL } from '@/constants/Auth';
 
@@ -31,6 +31,8 @@ export const logoutUser = async (): Promise<ServerResponse> => {
 export const reTakeToken = async (): Promise<ServerResponse> => {
   try {
     const response = await api.get('/auth/reissueToken');
+    const accessToken = response.data.content.accessToken;
+    setAccesToken(accessToken);
     return response.data;
   } catch (error) {
     const { response } = error as unknown as AxiosError;

--- a/api/Auth/index.ts
+++ b/api/Auth/index.ts
@@ -1,7 +1,7 @@
 import { SignUpResult } from './../../types/auth.d';
 import { ServerResponse } from '@/types/serverResponse';
 import api from '..';
-import { setAccesToken } from '@/utils/acceessToken';
+import { removeAccessToken, setAccesToken } from '@/utils/acceessToken';
 
 export const kakaoSignUp = async (code: string): Promise<ServerResponse<SignUpResult>> => {
   const { data } = await api.post(`/login/kakao?code=${code}`);
@@ -11,6 +11,17 @@ export const kakaoSignUp = async (code: string): Promise<ServerResponse<SignUpRe
 export const kakaoSignIn = async (code: string | null): Promise<ServerResponse<SignUpResult>> => {
   const { data } = await api.get(`/login/kakao?code=${code}`);
   return data;
+};
+
+export const logoutUser = async () => {
+  try {
+    const { data } = await api.post('/logout');
+    removeAccessToken();
+    return data;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
 };
 
 export const reTakeToken = async (): Promise<ServerResponse> => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -25,7 +25,7 @@ api.interceptors.response.use(
   },
   async (error) => {
     const { config, response } = error;
-    if (response.status === 401) {
+    if (response?.status === 401) {
       if (!lock) {
         lock = true;
         await reTakeToken();

--- a/api/index.ts
+++ b/api/index.ts
@@ -18,16 +18,6 @@ api.interceptors.request.use((config) => {
 });
 
 let lock = false;
-let subscribers: ((token: string) => void)[] = [];
-
-const addRefreshSubscriber = (callback: (token: string) => void) => {
-  subscribers.push(callback);
-};
-
-const onRefreshed = (token: string) => {
-  subscribers.forEach((callback) => callback(token));
-  subscribers = [];
-};
 
 api.interceptors.response.use(
   (response) => {
@@ -36,30 +26,12 @@ api.interceptors.response.use(
   async (error) => {
     const { config, response } = error;
     if (response.status === 401) {
-      const originalRequest = config;
-
       if (!lock) {
         lock = true;
         await reTakeToken();
-        const accessToken = getAccessToken();
-        // if (accessToken) {
-        // originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
-        // console.log(originalRequest);
-        // api(originalRequest);
-        // onRefreshed(accessToken);
         lock = false;
         return;
-        // }
       }
-
-      // const reTry = new Promise((resolve) => {
-      //   addRefreshSubscriber((token: string) => {
-      //     originalRequest.headers['Authorization'] = `Bearer ${token}`;
-      //     resolve(api(originalRequest));
-      //   });
-      // });
-
-      // return reTry;
     }
     return Promise.reject(error);
   },

--- a/common/Button/index.tsx
+++ b/common/Button/index.tsx
@@ -9,14 +9,23 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color?: 'primary' | 'black' | 'white' | 'disabled' | 'white-disabled';
   leftIcon?: JSX.Element;
   id?: string;
+  loading?: boolean;
 }
 
-const Button: FC<ButtonProps> = ({ children, width = '60px', height = '36px', onClick, leftIcon, color = 'primary', id }) => {
+const Button: FC<ButtonProps> = ({ children, width = '60px', height = '36px', onClick, leftIcon, color = 'primary', id, loading = false }) => {
   return (
-    <Style.Button width={width} height={height} color={color} onClick={onClick} disabled={color.includes('disabled')} id={id}>
+    <Style.Button width={width} height={height} color={color} onClick={onClick} disabled={color.includes('disabled') || loading} id={id}>
       <Style.InnerText>
-        {leftIcon && <Style.Icon>{leftIcon}</Style.Icon>}
-        {children}
+        {loading ? (
+          <Style.LoadingCircle color={color}>
+            <circle cx="50%" cy="50%" r="10"></circle>
+          </Style.LoadingCircle>
+        ) : (
+          <>
+            {leftIcon && <Style.Icon>{leftIcon}</Style.Icon>}
+            {children}
+          </>
+        )}
       </Style.InnerText>
     </Style.Button>
   );

--- a/common/Button/styles.ts
+++ b/common/Button/styles.ts
@@ -1,5 +1,6 @@
 import { ButtonProps } from './index';
 import styled from '@emotion/styled';
+import { keyframes } from '@emotion/react';
 
 export const Button = styled.button<ButtonProps>`
   ${({ theme }) => theme.font.subhead_02};
@@ -56,4 +57,44 @@ export const InnerText = styled.span`
 
 export const Icon = styled.span`
   height: 16px;
+`;
+
+const loading = keyframes`
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+const circleAnimation = keyframes`
+  0% {
+    stroke-dashoffset: 56;
+  }
+  75% {
+    stroke-dashoffset: -36;
+  }
+  100% {
+    stroke-dashoffset: -56;
+  }
+`;
+
+export const LoadingCircle = styled.svg<Pick<ButtonProps, 'color'>>`
+  width: 24px;
+  height: 24px;
+  animation: ${loading} 3s infinite;
+  circle {
+    stroke: ${({ theme, color }) => {
+      const colors = {
+        primary: theme.colors.secondary_100,
+        disabled: theme.colors.secondary_700,
+        black: theme.colors.secondary_100,
+        white: theme.colors.secondary_900,
+        ['white-disabled']: theme.colors.secondary_600,
+      };
+      return colors[color ?? 'primary'];
+    }};
+    stroke-width: 2;
+    stroke-dasharray: 56;
+    stroke-dashoffset: 0;
+    fill: none;
+    animation: ${circleAnimation} 1s infinite;
+  }
 `;

--- a/common/Modal/CreateGroupModal/index.tsx
+++ b/common/Modal/CreateGroupModal/index.tsx
@@ -29,7 +29,7 @@ export const CreateGroupModal: FC<ModalHandlerProps> = ({ modalHandler, id }) =>
 
   const location = useLocation();
 
-  const { mutate } = useCreateGroup(modalHandler);
+  const { mutate, isLoading } = useCreateGroup(modalHandler);
 
   const createGroup = () => {
     mutate(
@@ -72,7 +72,7 @@ export const CreateGroupModal: FC<ModalHandlerProps> = ({ modalHandler, id }) =>
         </Label>
       </Modal.Body>
       <Modal.Footer>
-        <Button id={id} onClick={createGroup} width="100%" height="42px" color={isValidForm() ? 'primary' : 'disabled'}>
+        <Button id={id} onClick={createGroup} width="100%" height="42px" color={isValidForm() ? 'primary' : 'disabled'} loading={isLoading}>
           만들기
         </Button>
       </Modal.Footer>

--- a/common/Modal/FineBookModal/index.tsx
+++ b/common/Modal/FineBookModal/index.tsx
@@ -50,8 +50,8 @@ export const FineBookModal = ({ setOpen, eventId, select, setSelect }: ModalProp
 
   const { groupId } = useParams();
   const { data } = useParticipantList(Number(groupId));
-  const { mutate: create } = useCreateDetail();
-  const { mutate: update } = useUpdateDetail();
+  const { mutate: create, isLoading: createLoading } = useCreateDetail();
+  const { mutate: update, isLoading: updateLoading } = useUpdateDetail();
 
   const user = useRecoilValue(userState);
   const navigate = useNavigate();
@@ -158,6 +158,7 @@ export const FineBookModal = ({ setOpen, eventId, select, setSelect }: ModalProp
               if (isCreate) return createDetail('save');
               updateDetail();
             }}
+            loading={isCreate ? createLoading : updateLoading}
             id={isCreate ? 'add_list_normal' : ''}
           >
             {isCreate ? '추가하기' : '저장하기'}

--- a/common/Modal/GroupSettingModal/AdminModal/index.tsx
+++ b/common/Modal/GroupSettingModal/AdminModal/index.tsx
@@ -30,7 +30,7 @@ export const AdminModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
 
   const { groupId } = useParams();
 
-  const { mutate: updateGroupMutate } = useUpdateGroup({ setError, modalHandler });
+  const { mutate: updateGroupMutate, isLoading } = useUpdateGroup({ setError, modalHandler });
   const { mutate: withdrawalGroupMutate } = useWithdrawalGroup();
   const { mutate: deleteGroup } = useDeleteGroup();
 
@@ -47,10 +47,6 @@ export const AdminModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
 
   const onDeleteGroup = () => {
     deleteGroup({ groupId: Number(groupId) });
-  };
-
-  const isFormValidate = () => {
-    return [setError('nickname', checkCountChar(nickname)), setError('groupName', checkCountChar(title))];
   };
 
   const updateGroupInfo = () => {
@@ -126,7 +122,7 @@ export const AdminModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
             <Button color="white" onClick={modalHandler}>
               취소
             </Button>
-            <Button color={isValidForm() ? 'black' : 'disabled'} onClick={updateGroupInfo} id="group_modify">
+            <Button color={isValidForm() ? 'black' : 'disabled'} onClick={updateGroupInfo} id="group_modify" loading={isLoading}>
               저장
             </Button>
           </Style.ButtonFrame>

--- a/layouts/Group/components/Header/index.tsx
+++ b/layouts/Group/components/Header/index.tsx
@@ -1,15 +1,12 @@
+import { logoutUser } from '@/api/Auth';
 import { ARROW } from '@/assets/icons/Arrow';
 import { LOGO } from '@/assets/icons/Logo';
 import { SYSTEM } from '@/assets/icons/System';
 import { USER } from '@/assets/icons/User';
 import DropDown from '@/common/DropDown';
-import { AuthModal } from '@/common/Modal/LoginModal';
 import { TwoButtonModal } from '@/common/Modal/TwoButtonModal';
 import UserConfigModal from '@/common/Modal/UserConfigModal';
 import { userState } from '@/store/userState';
-import { GroupListWithIndex } from '@/types/group';
-import { removeAccessToken } from '@/utils/acceessToken';
-import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
@@ -41,21 +38,8 @@ const GroupLayoutHeader = () => {
     setShowDropDown((prev) => !prev);
   };
 
-  const queryClient = useQueryClient();
-
   const onClickLogOut = () => {
-    removeAccessToken();
-    setUser({
-      userId: null,
-      email: '',
-    });
-
-    queryClient.setQueryData<GroupListWithIndex>(['groupList'], {
-      next: false,
-      index: 0,
-      groupList: [],
-    });
-    navigate('/');
+    logoutUser();
   };
 
   useEffect(() => {

--- a/pages/Home/components/Header/UserConfig/index.tsx
+++ b/pages/Home/components/Header/UserConfig/index.tsx
@@ -1,12 +1,10 @@
+import { logoutUser } from '@/api/Auth';
 import { ARROW } from '@/assets/icons/Arrow';
 import { SYSTEM } from '@/assets/icons/System';
 import { USER } from '@/assets/icons/User';
 import DropDown from '@/common/DropDown';
 import { TwoButtonModal } from '@/common/Modal/TwoButtonModal';
 import UserConfigModal from '@/common/Modal/UserConfigModal';
-import { GroupListWithIndex } from '@/types/group';
-import { removeAccessToken } from '@/utils/acceessToken';
-import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import * as Style from './style';
 
@@ -29,17 +27,8 @@ const UserConfig = () => {
     setShowDropDown((prev) => !prev);
   };
 
-  const queryClient = useQueryClient();
-
   const onClickLogOut = () => {
-    removeAccessToken();
-    localStorage.removeItem('recoil-persist');
-    queryClient.setQueryData<GroupListWithIndex>(['groupList'], {
-      next: false,
-      index: 0,
-      groupList: [],
-    });
-    window.location.href = process.env.REACT_APP_SERVICE_URL as string;
+    logoutUser();
   };
 
   useEffect(() => {

--- a/queries/Auth/useSignUpMutation.ts
+++ b/queries/Auth/useSignUpMutation.ts
@@ -1,4 +1,3 @@
-import { TOAST_ERROR } from './../../constants/Toast';
 import { useRecoilState } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -22,9 +21,6 @@ const useSignUpMutation = () => {
       }));
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.SIGNIN });
       navigate('/');
-    },
-    onError: (error) => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
     },
   });
 };

--- a/queries/Auth/useUserWithdrawalMutation.ts
+++ b/queries/Auth/useUserWithdrawalMutation.ts
@@ -28,17 +28,12 @@ const useUserWithdrawalMutation = () => {
     },
     onSuccess: async () => {
       removeAccessToken();
-      setUser({
-        userId: null,
-        email: '',
-      });
       navigate('/');
     },
     onError: (error, value, context) => {
       if (context?.previousData) {
         queryClient.setQueryData(['groupList'], context.previousData);
       }
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
     },
     onSettled: () => {
       queryClient.invalidateQueries(['groupList']);

--- a/queries/Auth/useUserWithdrawalMutation.ts
+++ b/queries/Auth/useUserWithdrawalMutation.ts
@@ -32,7 +32,6 @@ const useUserWithdrawalMutation = () => {
         userId: null,
         email: '',
       });
-      localStorage.removeItem('recoil-persist');
       navigate('/');
     },
     onError: (error, value, context) => {

--- a/queries/Detail/useCreateDetail.ts
+++ b/queries/Detail/useCreateDetail.ts
@@ -12,8 +12,5 @@ export const useCreateDetail = () => {
       queryClient.invalidateQueries(['monthStatus']);
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.CREATE_FINE });
     },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
   });
 };

--- a/queries/Detail/useDeleteDetail.ts
+++ b/queries/Detail/useDeleteDetail.ts
@@ -11,8 +11,5 @@ export const useDeleteDetail = () => {
       queryClient.invalidateQueries(['monthStatus']);
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.DELETE_FINE });
     },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
   });
 };

--- a/queries/Detail/useGetDetailList.ts
+++ b/queries/Detail/useGetDetailList.ts
@@ -9,9 +9,5 @@ import { Dayjs } from 'dayjs';
 export const useGetDetailList = (dateFilter: Partial<DateFilterProperty>, selectedDate: Dayjs | null, groupId: GroupId) => {
   const query = dateFilterToQuery(dateFilter);
 
-  return useQuery(['detailList', query, selectedDate, groupId.groupId], () => getEventList(query, groupId), {
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-    },
-  });
+  return useQuery(['detailList', query, selectedDate, groupId.groupId], () => getEventList(query, groupId));
 };

--- a/queries/Detail/useGetMonthStatus.ts
+++ b/queries/Detail/useGetMonthStatus.ts
@@ -6,8 +6,5 @@ import { useQuery } from '@tanstack/react-query';
 export const useGetMonthStatus = (groupId: string | undefined, year: string, month: string) => {
   return useQuery(['monthStatus', groupId, year, month], () => getMonthStatus(groupId, year, month), {
     enabled: !!groupId,
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-    },
   });
 };

--- a/queries/Detail/useGetOneOfDetail.ts
+++ b/queries/Detail/useGetOneOfDetail.ts
@@ -4,9 +4,5 @@ import { TOAST_ERROR } from '@/constants/Toast';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGetOneOfDetail = (eventId: number) => {
-  return useQuery(['oneOfDetail', eventId], () => getOneOfEvent(eventId), {
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-    },
-  });
+  return useQuery(['oneOfDetail', eventId], () => getOneOfEvent(eventId));
 };

--- a/queries/Detail/useUpdateDetail.ts
+++ b/queries/Detail/useUpdateDetail.ts
@@ -11,8 +11,5 @@ export const useUpdateDetail = () => {
       queryClient.invalidateQueries(['monthStatus']);
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.UPDATE_FINE });
     },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
   });
 };

--- a/queries/Detail/useUpdateDetailStatus.ts
+++ b/queries/Detail/useUpdateDetailStatus.ts
@@ -11,8 +11,5 @@ export const useUpdateDetailStatus = () => {
       queryClient.invalidateQueries(['monthStatus']);
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.UPDATE_FINE });
     },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
   });
 };

--- a/queries/Group/useChangeAdmin.ts
+++ b/queries/Group/useChangeAdmin.ts
@@ -1,4 +1,4 @@
-import { TOAST_ERROR, TOAST_SUCCESS } from '@/constants/Toast';
+import { TOAST_SUCCESS } from '@/constants/Toast';
 import { ToastPopUp } from './../../common/Toast/index';
 import { changeAdmin } from '@/api/Group';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -50,7 +50,6 @@ export const useChangeAdmin = (groupId: number | undefined) => {
       if (context?.prevGroupDetail) {
         queryClient.setQueryData(['groupDetail', value.groupId], context.prevGroupDetail);
       }
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
     },
     onSettled: () => {
       queryClient.invalidateQueries(['participantList', groupId]);

--- a/queries/Group/useChangeNickname.ts
+++ b/queries/Group/useChangeNickname.ts
@@ -1,4 +1,4 @@
-import { TOAST_ERROR, TOAST_SUCCESS } from '@/constants/Toast';
+import { TOAST_SUCCESS } from '@/constants/Toast';
 import { ToastPopUp } from '@/common/Toast';
 import { changeNickname } from '@/api/Group';
 import { useMutation } from '@tanstack/react-query';
@@ -17,12 +17,10 @@ export const useChangeNickname = ({ modalHandler, setError }: UseChangeNicknameP
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.UPDATE_GROUP });
     },
     onError: (error) => {
-      const axiosError = error as unknown as AxiosError;
-      if (axiosError.response) {
-        const data = axiosError.response.data as ServerResponse;
+      const { response } = error as unknown as AxiosError;
+      if (response && response.status !== 401) {
+        const data = response.data as ServerResponse;
         setError('nickname', data.status.message);
-      } else {
-        ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
       }
     },
   });

--- a/queries/Group/useCreateGroup.ts
+++ b/queries/Group/useCreateGroup.ts
@@ -3,8 +3,6 @@ import { createGroup } from '@/api/Group';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { firstVisitState } from '@/store/\bfirstVisitState';
-import { TOAST_ERROR } from '@/constants/Toast';
-import { ToastPopUp } from '@/common/Toast';
 
 export const useCreateGroup = (modalHandler: () => void) => {
   const navigate = useNavigate();
@@ -17,9 +15,6 @@ export const useCreateGroup = (modalHandler: () => void) => {
       setIsFirstVisit((prev) => ({ ...prev, isFirstVisit: true }));
       modalHandler();
       queryClient.invalidateQueries(['groupList']);
-    },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
     },
   });
 };

--- a/queries/Group/useCreateGroup.ts
+++ b/queries/Group/useCreateGroup.ts
@@ -1,5 +1,4 @@
 import { useRecoilState } from 'recoil';
-
 import { createGroup } from '@/api/Group';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -13,7 +12,7 @@ export const useCreateGroup = (modalHandler: () => void) => {
   const [_, setIsFirstVisit] = useRecoilState(firstVisitState);
 
   return useMutation(createGroup, {
-    onSuccess(data) {
+    onSuccess: (data) => {
       navigate(`/group/${data.content.groupId}/book`);
       setIsFirstVisit((prev) => ({ ...prev, isFirstVisit: true }));
       modalHandler();

--- a/queries/Group/useDeleteGroup.ts
+++ b/queries/Group/useDeleteGroup.ts
@@ -1,6 +1,5 @@
 import { ServerResponse } from './../../types/serverResponse.d';
-import { TOAST_ERROR, TOAST_SUCCESS } from '@/constants/Toast';
-
+import { TOAST_SUCCESS } from '@/constants/Toast';
 import { deleteGroup } from '@/api/Group';
 import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ToastPopUp } from '@/common/Toast';
@@ -30,9 +29,7 @@ export const useDeleteGroup = () => {
       navigate('/');
       ToastPopUp({ type: 'success', message: TOAST_SUCCESS.GROUP_DELETE });
     },
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
+
     onSettled: () => {
       queryClient.invalidateQueries(['groupList']);
     },

--- a/queries/Group/useGetMyNickname.ts
+++ b/queries/Group/useGetMyNickname.ts
@@ -1,12 +1,6 @@
 import { getMyNickname } from '@/api/Group';
-import { ToastPopUp } from '@/common/Toast';
-import { TOAST_ERROR } from '@/constants/Toast';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGetMyNikname = (groupId: number | undefined) => {
-  return useQuery(['myNickname', groupId], () => getMyNickname(groupId), {
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
-    },
-  });
+  return useQuery(['myNickname', groupId], () => getMyNickname(groupId), {});
 };

--- a/queries/Group/useGroupDetail.ts
+++ b/queries/Group/useGroupDetail.ts
@@ -1,13 +1,6 @@
 import { getGroupDetail } from '@/api/Group';
-import { ToastPopUp } from '@/common/Toast';
-import { TOAST_ERROR } from '@/constants/Toast';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
 export const useGroupDetail = (groupId: number | undefined) => {
-  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId), {
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-    },
-  });
+  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId));
 };

--- a/queries/Group/useGroupList.ts
+++ b/queries/Group/useGroupList.ts
@@ -1,24 +1,11 @@
-import { AxiosError } from 'axios';
 import { getGroupList } from '@/api/Group';
-import { ToastPopUp } from '@/common/Toast';
-import { TOAST_ERROR } from '@/constants/Toast';
-
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getAccessToken } from '@/utils/acceessToken';
 
 export const useGroupList = () => {
   return useInfiniteQuery(['groupList'], ({ pageParam = 0 }) => getGroupList(pageParam), {
-    retry: 0,
     getNextPageParam: (context) => {
       return context?.content?.next ? context.nextPage : undefined;
-    },
-    onError: (error) => {
-      const { response } = error as unknown as AxiosError;
-      if (response) {
-        if (response.status !== 400) {
-          ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-        }
-      }
     },
     enabled: !!getAccessToken(),
   });

--- a/queries/Group/useGroupList.ts
+++ b/queries/Group/useGroupList.ts
@@ -8,6 +8,7 @@ import { getAccessToken } from '@/utils/acceessToken';
 
 export const useGroupList = () => {
   return useInfiniteQuery(['groupList'], ({ pageParam = 0 }) => getGroupList(pageParam), {
+    retry: 0,
     getNextPageParam: (context) => {
       return context?.content?.next ? context.nextPage : undefined;
     },

--- a/queries/Group/useParticipantList.ts
+++ b/queries/Group/useParticipantList.ts
@@ -1,12 +1,6 @@
 import { getParticipantList } from '@/api/Group';
-import { ToastPopUp } from '@/common/Toast';
-import { TOAST_ERROR } from '@/constants/Toast';
 import { useQuery } from '@tanstack/react-query';
 
 export const useParticipantList = (groupId: number | undefined) => {
-  return useQuery(['participantList', groupId], () => getParticipantList(groupId), {
-    onError: () => {
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.DATA });
-    },
-  });
+  return useQuery(['participantList', groupId], () => getParticipantList(groupId));
 };

--- a/queries/Group/useUpdateGroup.ts
+++ b/queries/Group/useUpdateGroup.ts
@@ -1,7 +1,7 @@
 import { ServerResponse } from '@/types/serverResponse';
 import { updateGroup } from '@/api/Group';
 import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
-import { TOAST_ERROR, TOAST_SUCCESS } from '@/constants/Toast';
+import { TOAST_SUCCESS } from '@/constants/Toast';
 import { ToastPopUp } from '@/common/Toast';
 import { AxiosError } from 'axios';
 import { GroupDetail, GroupListWithIndex, GroupNickname, ParticipantList } from '@/types/group';
@@ -83,8 +83,6 @@ export const useUpdateGroup = ({ modalHandler, setError }: UseUpdateGroup) => {
       if (axiosError.response) {
         const data = axiosError.response.data as ServerResponse;
         setError('nickname', data.status.message);
-      } else {
-        ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
       }
     },
     onSettled: (context) => {

--- a/queries/Group/useWithdrawalGroup.ts
+++ b/queries/Group/useWithdrawalGroup.ts
@@ -1,4 +1,4 @@
-import { TOAST_ERROR, TOAST_SUCCESS } from '@/constants/Toast';
+import { TOAST_SUCCESS } from '@/constants/Toast';
 import { ToastPopUp } from '@/common/Toast';
 import { useNavigate } from 'react-router-dom';
 import { withdrawalGroup } from '@/api/Group';
@@ -34,7 +34,6 @@ export const useWithdrawalGroup = () => {
       if (context?.previousData) {
         queryClient.setQueryData(['groupList'], context.previousData);
       }
-      ToastPopUp({ type: 'error', message: TOAST_ERROR.NETWORK });
     },
     onSettled: () => {
       queryClient.invalidateQueries(['groupList']);

--- a/store/userState.ts
+++ b/store/userState.ts
@@ -5,14 +5,14 @@ const { persistAtom } = recoilPersist({
 });
 
 export interface UserState {
-  email: string;
+  email: string | null;
   userId: number | null;
 }
 
 export const userState = atom<UserState>({
   key: 'userState',
   default: {
-    email: '',
+    email: null,
     userId: null,
   },
   effects_UNSTABLE: [persistAtom],

--- a/utils/acceessToken.ts
+++ b/utils/acceessToken.ts
@@ -5,5 +5,7 @@ export const getAccessToken = () => {
   return localStorage.getItem('accessToken');
 };
 export const removeAccessToken = () => {
-  return localStorage.removeItem('accessToken');
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('recoil-persist');
+  return;
 };


### PR DESCRIPTION
- logout API 추가
- reTakeToken 상태 코드 403 일 경우( 리프레시 토큰 훼손) 재 로그인, 406 일 경우( 리프레시 토큰 없음) 메인페이지 로 리다이렉트 및 유저 정보 지우기
- 리액트 쿼리 401 외의 상태 코드 글로벌에서 토스트 팝업으로 처리