### PR TITLE
Feat : api 변경으로 인한 모임, 상세내역 msw api 수정

### DIFF
--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -1,49 +1,60 @@
 import { BASE_URL } from '@/api';
-import { EventInfo } from '@/types/event';
 import { rest } from 'msw';
 
+/**
+ * 상세 내역 생성시 데이터
+ * groupId: number
+ * "nickname" : String-"${팀원이름}"
+ * "date" : String-"${사유 발생 날짜}" 23.06.01
+ * "amount" : int-"${금액}" 1000
+ * "ground" : String-"${사유}" 지각 | 결석 | 과제 안 함 | 기타
+ * "memo" : String-"${메모}" 밥먹다 지각
+ * "situation" : String-"${납부 여부}" 미납, 완납, 확인중
+ */
+
+type Ground = '지각' | '결석' | '과제 안 함' | '기타';
+type Situation = '미납' | '완납' | '확인중';
+
+type EventInfo = {
+  eventId: number;
+  groupId: number;
+  nickname: string;
+  date: string;
+  amount: number;
+  ground: Ground;
+  memo: string;
+  situation: Situation;
+};
+
 const details: EventInfo[] = [
-  { userId: 1, eventId: 1, groundsDate: '2023.07.01', paymentType: 'con', userName: '윤하나둘셋', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 2, eventId: 2, groundsDate: '2023.07.04', paymentType: 'non', userName: '윤하나둘셋13', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 3, eventId: 3, groundsDate: '2023.07.15', paymentType: 'full', userName: '윤하나둘셋23', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 4, eventId: 4, groundsDate: '2023.07.08', paymentType: 'con', userName: '윤하나둘셋33', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 5, eventId: 5, groundsDate: '2023.07.29', paymentType: 'full', userName: '윤하나둘셋45', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 6, eventId: 6, groundsDate: '2023.07.22', paymentType: 'non', userName: '윤하나둘셋14', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 7, eventId: 7, groundsDate: '2023.02.22', paymentType: 'con', userName: '윤하나둘셋245', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 8, eventId: 8, groundsDate: '2023.07.04', paymentType: 'con', userName: '윤하나둘셋614', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 9, eventId: 9, groundsDate: '2023.07.15', paymentType: 'full', userName: '윤하나둘셋fdas', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 10, eventId: 10, groundsDate: '2023.07.08', paymentType: 'con', userName: '윤하나둘셋6136', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 11, eventId: 11, groundsDate: '2023.07.29', paymentType: 'full', userName: '윤하나둘셋66', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 12, eventId: 12, groundsDate: '2023.02.22', paymentType: 'con', userName: '윤하나둘셋141', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 13, eventId: 13, groundsDate: '2023.08.04', paymentType: 'non', userName: '윤하나둘셋3214', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 14, eventId: 14, groundsDate: '2023.08.15', paymentType: 'full', userName: '윤하나532둘셋', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 15, eventId: 15, groundsDate: '2023.08.08', paymentType: 'con', userName: '윤하나둘1616셋', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 16, eventId: 16, groundsDate: '2023.08.29', paymentType: 'full', userName: '윤하나둘5124셋', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 17, eventId: 17, groundsDate: '2023.07.22', paymentType: 'non', userName: '윤하나둘셋g', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 18, eventId: 18, groundsDate: '2023.02.22', paymentType: 'con', userName: '윤하나둘셋1', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 19, eventId: 19, groundsDate: '2023.07.04', paymentType: 'non', userName: '윤하나둘셋6', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 20, eventId: 20, groundsDate: '2023.07.15', paymentType: 'full', userName: '윤하나둘셋b', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 21, eventId: 21, groundsDate: '2023.07.30', paymentType: 'con', userName: '윤하나둘셋e', payment: 1_000_000, grounds: '밥먹다 지각' },
-  { userId: 22, eventId: 22, groundsDate: '2023.07.29', paymentType: 'full', userName: '윤하나둘셋g', payment: 1_000_000, grounds: '밥먹다 지각' },
+  { eventId: 1, groupId: 1, nickname: '종현', date: '2023.06.25', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 2, groupId: 1, nickname: '정민', date: '2023.06.30', amount: 10_000, ground: '결석', memo: '', situation: '완납' },
+  { eventId: 3, groupId: 1, nickname: '윤하나', date: '2023.07.01', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 4, groupId: 1, nickname: '가람', date: '2023.06.25', amount: 10_000, ground: '과제 안 함', memo: '', situation: '확인중' },
+  { eventId: 5, groupId: 1, nickname: '나경', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '확인중' },
+  { eventId: 6, groupId: 1, nickname: '현교', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 7, groupId: 1, nickname: '재민', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '완납' },
 ];
 
-const createDetail: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
-  const detail = await req.json();
-  const eventId = details.length;
-  details.push({ ...detail, eventId });
+const createDetail = () => {
+  return rest.post(BASE_URL + '/api/event/penalty', async (req, res, ctx) => {
+    const newDetail = await req.json();
+    const eventId = details.length;
+    details.push({ ...newDetail, eventId });
 
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '상세 내역이 성공적으로 생성되었습니다.',
-      },
-      content: {
-        eventId,
-      },
-    }),
-  );
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역이 성공적으로 생성되었습니다.',
+        },
+        content: {
+          eventId,
+        },
+      }),
+    );
+  });
 };
 
 //서버 코드 변경되면 적용 예정
@@ -96,7 +107,7 @@ const deleteDetailStatus: Parameters<typeof rest.put>[1] = async (req, res, ctx)
 };
 
 export const detailHandler = [
-  rest.post(BASE_URL + '/api/event/penalty', createDetail),
+  createDetail(),
   rest.get(BASE_URL + '/api/event/penalty/list/:groupId', getDetailList),
   rest.post(BASE_URL + '/api/event/penalty/:eventId', updateDetailStatus),
   rest.put(BASE_URL + '/api/event/penalty/:eventId', deleteDetailStatus),

--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -57,6 +57,26 @@ const createDetail = () => {
   });
 };
 
+const getDetail = () => {
+  return rest.get(BASE_URL + '/api/event/penalty/:eventId', async (req, res, ctx) => {
+    const { eventId } = req.params;
+
+    const detail = details.find((detail) => detail.eventId === Number(eventId));
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역이 성공적으로 조회되었습니다.',
+        },
+        content: {
+          ...detail,
+        },
+      }),
+    );
+  });
+};
+
 //서버 코드 변경되면 적용 예정
 const getDetailList: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
   // console.log(req.url.searchParams.get('year'));
@@ -108,6 +128,7 @@ const deleteDetailStatus: Parameters<typeof rest.put>[1] = async (req, res, ctx)
 
 export const detailHandler = [
   createDetail(),
+  getDetail(),
   rest.get(BASE_URL + '/api/event/penalty/list/:groupId', getDetailList),
   rest.post(BASE_URL + '/api/event/penalty/:eventId', updateDetailStatus),
   rest.put(BASE_URL + '/api/event/penalty/:eventId', deleteDetailStatus),

--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -1,45 +1,13 @@
 import { BASE_URL } from '@/api';
 import { PathParams, rest, RestRequest } from 'msw';
 import dayjs from 'dayjs';
+import { DETAILS } from '../data/detailData';
 
-/**
- * 상세 내역 생성시 데이터
- * groupId: number
- * "nickname" : String-"${팀원이름}"
- * "date" : String-"${사유 발생 날짜}" 23.06.01
- * "amount" : int-"${금액}" 1000
- * "ground" : String-"${사유}" 지각 | 결석 | 과제 안 함 | 기타
- * "memo" : String-"${메모}" 밥먹다 지각
- * "situation" : String-"${납부 여부}" 미납, 완납, 확인중
- */
+let details = DETAILS;
 
 const getSearchParams = (req: RestRequest<never, PathParams<string>>, param: string) => {
   return req.url.searchParams.get(param);
 };
-
-type Ground = '지각' | '결석' | '과제 안 함' | '기타';
-type Situation = '미납' | '완납' | '확인중';
-
-type EventInfo = {
-  eventId: number;
-  groupId: number;
-  nickname: string;
-  date: string;
-  amount: number;
-  ground: Ground;
-  memo: string;
-  situation: Situation;
-};
-
-let details: EventInfo[] = [
-  { eventId: 1, groupId: 1, nickname: '종현', date: '2023.06.25', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
-  { eventId: 2, groupId: 1, nickname: '정민', date: '2023.06.30', amount: 10_000, ground: '결석', memo: '', situation: '완납' },
-  { eventId: 3, groupId: 1, nickname: '윤하나', date: '2023.07.01', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
-  { eventId: 4, groupId: 1, nickname: '가람', date: '2023.06.25', amount: 10_000, ground: '과제 안 함', memo: '', situation: '확인중' },
-  { eventId: 5, groupId: 1, nickname: '나경', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '확인중' },
-  { eventId: 6, groupId: 1, nickname: '현교', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
-  { eventId: 7, groupId: 1, nickname: '재민', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '완납' },
-];
 
 const createDetail = () => {
   return rest.post(BASE_URL + '/api/event/penalty', async (req, res, ctx) => {

--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -31,7 +31,7 @@ type EventInfo = {
   situation: Situation;
 };
 
-const details: EventInfo[] = [
+let details: EventInfo[] = [
   { eventId: 1, groupId: 1, nickname: '종현', date: '2023.06.25', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
   { eventId: 2, groupId: 1, nickname: '정민', date: '2023.06.30', amount: 10_000, ground: '결석', memo: '', situation: '완납' },
   { eventId: 3, groupId: 1, nickname: '윤하나', date: '2023.07.01', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
@@ -124,40 +124,78 @@ const getDetailList = () => {
   });
 };
 
-//서버 코드 변경되면 적용 예정
+const updateDetailListStatus = () => {
+  return rest.patch(BASE_URL + '/api/event/penalty', async (req, res, ctx) => {
+    const { eventId } = req.params;
 
-const updateDetailStatus: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '납부 여부가 성공적으로 변경되었습니다.',
-      },
-      content: details[1],
-    }),
-  );
+    const { eventIdList, situation } = await req.json();
+
+    details = details.map((detail) => {
+      if (eventIdList.includes(detail.eventId)) {
+        return { ...detail, situation };
+      }
+      return detail;
+    });
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역 목록이 성공적으로 조회되었습니다.',
+        },
+        content: eventIdList,
+      }),
+    );
+  });
 };
 
-const deleteDetailStatus: Parameters<typeof rest.put>[1] = async (req, res, ctx) => {
-  const { eventId } = req.params;
+const updateDetail = () => {
+  return rest.patch(BASE_URL + '/api/event/penalty/:eventId', async (req, res, ctx) => {
+    const updatedDetail = await req.json();
+    const { eventId } = req.params;
+    let detail = details.find((detail) => detail.eventId === Number(eventId));
+    detail = updatedDetail;
 
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '납부 여부가 성공적으로 변경되었습니다.',
-      },
-      content: details[1],
-    }),
-  );
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역이 성공적으로 생성되었습니다.',
+        },
+        content: {
+          eventId,
+        },
+      }),
+    );
+  });
+};
+
+const deleteDetail = () => {
+  return rest.delete(BASE_URL + '/api/event/penalty/:eventId', async (req, res, ctx) => {
+    const { eventId } = req.params;
+
+    details = details.filter((detail) => detail.eventId === Number(eventId));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역이 성공적으로 삭제되었습니다.',
+        },
+        content: null,
+      }),
+    );
+  });
 };
 
 export const detailHandler = [
-  createDetail(),
+  createDetail(), //
   getDetail(),
   getDetailList(),
-  rest.post(BASE_URL + '/api/event/penalty/:eventId', updateDetailStatus),
-  rest.put(BASE_URL + '/api/event/penalty/:eventId', deleteDetailStatus),
+  updateDetailListStatus(),
+  updateDetail(),
+  deleteDetail(),
 ];

--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -1,13 +1,10 @@
 import { BASE_URL } from '@/api';
-import { PathParams, rest, RestRequest } from 'msw';
+import { rest } from 'msw';
 import dayjs from 'dayjs';
 import { DETAILS } from '../data/detailData';
+import { getSearchParams } from '../utils/getSearchParams';
 
 let details = DETAILS;
-
-const getSearchParams = (req: RestRequest<never, PathParams<string>>, param: string) => {
-  return req.url.searchParams.get(param);
-};
 
 const createDetail = () => {
   return rest.post(BASE_URL + '/api/event/penalty', async (req, res, ctx) => {

--- a/src/mocks/api/detailHandler.ts
+++ b/src/mocks/api/detailHandler.ts
@@ -191,6 +191,44 @@ const deleteDetail = () => {
   });
 };
 
+const getCalendarStatus = () => {
+  return rest.get(BASE_URL + '/api/event/penalty/calendar', async (req, res, ctx) => {
+    const groupId = getSearchParams(req, 'groupId');
+    const startDate = getSearchParams(req, 'startDate');
+    const endDate = getSearchParams(req, 'endDate');
+
+    const filteredDetails = details.filter((detail) => {
+      if (
+        Number(groupId) === detail.groupId && //
+        dayjs(detail.date).isAfter(dayjs(startDate as string)) &&
+        dayjs(detail.date).isBefore(dayjs(endDate as string))
+      ) {
+        return true;
+      }
+      return false;
+    });
+
+    const statusOfDay = filteredDetails.reduce((accr: { [date: string]: { 미납: number; 완납: number; 확인중: number } }, curr) => {
+      const date = dayjs(curr.date).date();
+      const statusOfDay = accr[date] ?? { 미납: 0, 완납: 0, 확인중: 0 };
+      statusOfDay[curr.situation]++;
+
+      return { ...accr, [date]: statusOfDay };
+    }, {});
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '상세 내역 캘린더가 성공적으로 조회되었습니다.',
+        },
+        content: { statusOfDay },
+      }),
+    );
+  });
+};
+
 export const detailHandler = [
   createDetail(), //
   getDetail(),
@@ -198,4 +236,5 @@ export const detailHandler = [
   updateDetailListStatus(),
   updateDetail(),
   deleteDetail(),
+  getCalendarStatus(),
 ];

--- a/src/mocks/api/groupHandler.ts
+++ b/src/mocks/api/groupHandler.ts
@@ -1,205 +1,166 @@
-import { GropuList } from '@/types/group';
 import { rest } from 'msw';
 import { BASE_URL } from '@/api';
+import { GROUP_LIST } from '../data/groupData';
+import { getSearchParams } from '../utils/getSearchParams';
 
-const groupList: GropuList[] = [
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', groupId: 1, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나', coverColor: '#f86565', groupId: 2, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤둘', coverColor: '#f86565', groupId: 3, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤셋', coverColor: '#f86565', groupId: 4, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤넷', coverColor: '#f86565', groupId: 5, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘', coverColor: '#f86565', groupId: 6, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나셋넷', coverColor: '#f86565', groupId: 7, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤둘셋넷', coverColor: '#f86565', groupId: 8, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 9, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 10, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 11, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 12, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 13, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 14, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 15, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 16, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 17, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 18, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 19, type: '스터디' },
-];
+let groupList = GROUP_LIST;
 
-export const getGroupList: Parameters<typeof rest.get>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: 'success',
-      },
-      content: {
-        index: 0,
-        next: false,
-        groupList,
-      },
-    }),
-  );
+const getGroupList = () => {
+  rest.get(BASE_URL + '/api/groups', async (req, res, ctx) => {
+    const page = getSearchParams(req, 'page');
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 200,
+          message: 'success',
+        },
+        content: {
+          hasNext: false,
+          groupList,
+        },
+      }),
+    );
+  });
 };
 
-const getGroupDetail: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
-  const groupId = req.url.searchParams.get('groupId');
+const getGroupDetail = (isAdmin = true, isInto = true) => {
+  return rest.get(BASE_URL + '/api/group/:groupId', (req, res, ctx) => {
+    const { groupId } = req.params;
 
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '모임이 성공적으로 조회되었습니다.',
-      },
-      content: {
-        title: '전국 노래 자랑',
-        adminNickname: '윤하나둘셋넷',
-        coverColor: '#f86565',
-        type: '학교, 교내/외 모임',
-        isAdmin: false,
-        isInto: false,
-        groupId,
-        size: 2,
-      },
-    }),
-  );
+    const group = groupList.find((group) => group.groupId === Number(groupId));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 200,
+          message: '모임이 성공적으로 조회되었습니다.',
+        },
+        content: {
+          ...group,
+          isAdmin,
+          isInto,
+          size: 2,
+        },
+      }),
+    );
+  });
 };
 
-const getGroupParticipant: Parameters<typeof rest.get>[1] = (req, res, ctx) => {
-  return res(
-    ctx.json({
-      status: {
-        code: 200,
-        message: '모임 참가자 리스트가 정상적으로 조회되었습니다.',
-      },
-      content: {
-        adminId: '1',
-        adminNickname: '윤하나둘셋넷',
-        memberList: [
-          { nickname: '윤하나둘셋넷', userId: 0 },
-          { nickname: '윤하나', userId: 1 },
-          { nickname: '윤둘', userId: 2 },
-          { nickname: '윤셋', userId: 3 },
-          { nickname: '윤넷', userId: 4 },
-          { nickname: '윤하나둘', userId: 5 },
-          { nickname: '윤하나셋넷', userId: 6 },
-        ],
-      },
-    }),
-  );
+const getGroupParticipant = () => {
+  return rest.get(BASE_URL + '/api/group/:groupId/participants', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        status: {
+          code: 200,
+          message: '모임 참가자 리스트가 정상적으로 조회되었습니다.',
+        },
+        content: {
+          adminNickname: '윤하나둘셋넷',
+          nicknameList: ['윤하나', '윤둘', '윤셋', '윤넷', '윤하나둘', '윤하나셋넷'],
+        },
+      }),
+    );
+  });
 };
 
-const createGroup: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
-  const body = await req.json();
-  groupList.push(body);
-  return res(
-    ctx.status(201),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '모임이 성공적으로 생성되었습니다.',
-      },
-      content: {
-        group_id: '10',
-      },
-    }),
-  );
+const createGroup = () => {
+  return rest.post(BASE_URL + '/api/group', async (req, res, ctx) => {
+    const body = await req.json();
+
+    const groupId = groupList.length;
+    const group = {
+      ...body,
+      adminNickname: body.nickname,
+      groupId,
+    };
+
+    groupList.unshift(group);
+    return res(
+      ctx.status(201),
+      ctx.json({
+        status: {
+          code: 900,
+          message: '모임이 성공적으로 생성되었습니다.',
+        },
+        content: {
+          group_id: groupId,
+        },
+      }),
+    );
+  });
 };
 
-const modifyGroup: Parameters<typeof rest.put>[1] = (req, res, ctx) => {
-  return res(ctx.status(201));
+const modifyGroup = () => {
+  return rest.patch(BASE_URL + '/api/group/:groupId', async (req, res, ctx) => {
+    const { groupId } = req.params;
+    const body = await req.json();
+
+    let group = groupList.find((group) => group.groupId === Number(groupId));
+
+    group = {
+      ...body,
+    };
+
+    return res(
+      ctx.status(201),
+      ctx.json({
+        status: {
+          code: 200,
+          message: '모임이 성공적으로 수정되었습니다.',
+        },
+        content: { groupId: Number(groupId) },
+      }),
+    );
+  });
 };
 
-const deleteGroup: Parameters<typeof rest.delete>[1] = (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '모임이 성공적으로 삭제되었습니다.',
-      },
-      content: null,
-    }),
-  );
+const deleteGroup = () => {
+  return rest.delete(BASE_URL + '/api/group/:groupId', (req, res, ctx) => {
+    const { groupId } = req.params;
+
+    groupList = groupList.filter((group) => group.groupId !== Number(groupId));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 200,
+          message: '모임이 성공적으로 삭제되었습니다.',
+        },
+        content: null,
+      }),
+    );
+  });
 };
 
-const joinGroup: Parameters<typeof rest.post>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(201),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '모임에 성공적으로 참가되었습니다.',
-      },
-      content: null,
-    }),
-  );
-};
+const getMyNikckname = () => {
+  return rest.get('/api/group/:groupId/participant', (req, res, ctx) => {
+    const { groupId } = req.params;
 
-const changeAdmin: Parameters<typeof rest.patch>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(201),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '관리자가 성공적으로 변경되었습니다.',
-      },
-      content: null,
-    }),
-  );
-};
-
-const withdrawalGroup: Parameters<typeof rest.delete>[1] = (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '성공적으로 모임에서 탈퇴되었습니다.',
-      },
-      content: null,
-    }),
-  );
-};
-
-const changeNickname: Parameters<typeof rest.patch>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(201),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '성공적으로 닉네임이 수정되었습니다.',
-      },
-      content: null,
-    }),
-  );
-};
-
-const getMyNikckname: Parameters<typeof rest.get>[1] = async (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      status: {
-        code: 200,
-        message: '성공적으로 닉네임을 조회했습니다',
-      },
-      content: {
-        nickname: '유저 닉네임',
-      },
-    }),
-  );
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: {
+          code: 200,
+          message: '성공적으로 닉네임을 조회했습니다',
+        },
+        content: {
+          nickname: '유저 닉네임',
+        },
+      }),
+    );
+  });
 };
 
 export const groupHandler = [
-  rest.get(BASE_URL + '/api/group/:groupId', getGroupDetail),
-  rest.get(BASE_URL + '/api/groups', getGroupList),
-  rest.get(BASE_URL + '/api/group/1/participants', getGroupParticipant),
-  rest.post(BASE_URL + '/api/group', createGroup),
-  rest.post(BASE_URL + '/api/group/1/participant', joinGroup),
-  rest.put(BASE_URL + '/api/group/1', modifyGroup),
-  rest.patch(BASE_URL + '/api/group/admin/1', changeAdmin),
-  rest.patch(BASE_URL + '/api/participant/1', changeNickname),
-  rest.delete(BASE_URL + '/api/group/1', deleteGroup),
-  rest.delete(BASE_URL + '/api/group/1', withdrawalGroup),
-  rest.get(BASE_URL + '/api/group/1/participant', getMyNikckname),
+  getGroupDetail(), //
+  createGroup(),
+  getGroupList(),
+  getGroupParticipant(),
+  modifyGroup(),
+  deleteGroup(),
+  getMyNikckname(),
 ];

--- a/src/mocks/data/detailData.ts
+++ b/src/mocks/data/detailData.ts
@@ -1,0 +1,23 @@
+type Ground = '지각' | '결석' | '과제 안 함' | '기타';
+type Situation = '미납' | '완납' | '확인중';
+
+type EventInfo = {
+  eventId: number;
+  groupId: number;
+  nickname: string;
+  date: string;
+  amount: number;
+  ground: Ground;
+  memo: string;
+  situation: Situation;
+};
+
+export const DETAILS: EventInfo[] = [
+  { eventId: 1, groupId: 1, nickname: '종현', date: '2023.06.25', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 2, groupId: 1, nickname: '정민', date: '2023.06.30', amount: 10_000, ground: '결석', memo: '', situation: '완납' },
+  { eventId: 3, groupId: 1, nickname: '윤하나', date: '2023.07.01', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 4, groupId: 1, nickname: '가람', date: '2023.06.25', amount: 10_000, ground: '과제 안 함', memo: '', situation: '확인중' },
+  { eventId: 5, groupId: 1, nickname: '나경', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '확인중' },
+  { eventId: 6, groupId: 1, nickname: '현교', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '미납' },
+  { eventId: 7, groupId: 1, nickname: '재민', date: '2023.07.04', amount: 10_000, ground: '지각', memo: '', situation: '완납' },
+];

--- a/src/mocks/data/groupData.ts
+++ b/src/mocks/data/groupData.ts
@@ -1,13 +1,23 @@
-import { GropuList } from '@/types/group';
+import { GroupColor, GroupType } from '@/types/group';
 
-export const GROUP_LIST: GropuList[] = [
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', groupId: 1, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나', coverColor: '#f86565', groupId: 2, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤둘', coverColor: '#f86565', groupId: 3, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤셋', coverColor: '#f86565', groupId: 4, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤넷', coverColor: '#f86565', groupId: 5, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘', coverColor: '#f86565', groupId: 6, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나셋넷', coverColor: '#f86565', groupId: 7, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤둘셋넷', coverColor: '#f86565', groupId: 8, type: '스터디' },
-  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 9, type: '스터디' },
+// Todo: tanstack-query 수정하면서 기존 GroupInfo 타입 이 형태로 변경해야 함
+type GroupInfo = {
+  title: string;
+  adminNickname: string;
+  coverColor: GroupColor;
+  groupId: number;
+  type: GroupType;
+  size: number;
+};
+
+export const GROUP_LIST: GroupInfo[] = [
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', groupId: 1, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤하나', coverColor: '#f86565', groupId: 2, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤둘', coverColor: '#f86565', groupId: 3, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤셋', coverColor: '#f86565', groupId: 4, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤넷', coverColor: '#f86565', groupId: 5, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘', coverColor: '#f86565', groupId: 6, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤하나셋넷', coverColor: '#f86565', groupId: 7, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤둘셋넷', coverColor: '#f86565', groupId: 8, type: '스터디', size: 2 },
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 9, type: '스터디', size: 2 },
 ];

--- a/src/mocks/data/groupData.ts
+++ b/src/mocks/data/groupData.ts
@@ -1,0 +1,13 @@
+import { GropuList } from '@/types/group';
+
+export const GROUP_LIST: GropuList[] = [
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘셋넷', coverColor: '#f86565', groupId: 1, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤하나', coverColor: '#f86565', groupId: 2, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤둘', coverColor: '#f86565', groupId: 3, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤셋', coverColor: '#f86565', groupId: 4, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤넷', coverColor: '#f86565', groupId: 5, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘', coverColor: '#f86565', groupId: 6, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤하나셋넷', coverColor: '#f86565', groupId: 7, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤둘셋넷', coverColor: '#f86565', groupId: 8, type: '스터디' },
+  { title: '전국 노래 자랑', adminNickname: '윤하나둘넷', coverColor: '#f86565', groupId: 9, type: '스터디' },
+];

--- a/src/mocks/utils/getSearchParams.ts
+++ b/src/mocks/utils/getSearchParams.ts
@@ -1,0 +1,5 @@
+import { PathParams, RestRequest } from 'msw';
+
+export const getSearchParams = (req: RestRequest<never, PathParams<string>>, param: string) => {
+  return req.url.searchParams.get(param);
+};


### PR DESCRIPTION
## 👀 개요

모임, 상세내역 msw api 수정했습니다 Closes #104 

<br />

## 🧑‍💻 구현 디테일 및 화면

- 모임, 상세내역 msw api 수정  
- getGroupDetail(모임 상세 조회)는 isAdmin, isInto를 param으로 전달받아 추후 테스트 시  전달해서 사용하면 됩니다 ! b6cfbb26f4dc84e1545d6fd292111ba5b4efc7cf
- /mocks/api 안에 함께 존재하던 data 따로 파일 분리해봤습니다 ! 2f9bea52d886598cc593e319157ca0c4f0942248


## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

- 아직 useQuery들 업데이트를 안 해서 작동은 안 하지만 업데이트 된 후에 client.tsx에 주석처리된 부분 제거하면 테스트 하실 수 있습니다 !

