### PR TITLE
Fix: 멤버 리스트 UI 버그 수정 및 페이지의 한글이 번역되는 현상 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     </script>
     <!— End Google Tag Manager —>
     <meta charset="UTF-8" />
+    <!-- 한글을 영어로 인식하고 번역해서 이상한 워딩으로 변경되는 현상 방지 -->
+    <meta name="google" content="notranslate" />
     <link rel="icon" href="/public/favicon.ico" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/assets/icons/Arrow/index.tsx
+++ b/src/assets/icons/Arrow/index.tsx
@@ -8,8 +8,8 @@ import Solid from './Solid.svg';
 export const ARROW = {
   DOUBLE_RIGHT: <DoubleRight />,
   DOUBLE_LEFT: <DoubleLeft />,
-  DOWN_SM: <Down width={16} height={16} />,
-  DOWN_LG: <Down width={24} height={24} fill="" />,
+  DOWN_SM: <Down width={16} height={16} fill="#3C3C3C" />,
+  DOWN_LG: <Down width={24} height={24} fill="#3C3C3C" />,
   DOWN_LG_NON_FOCUS: <Down width={24} height={24} fill="#BDBDBD" />,
   LEFT: <Left width={8} height={12} />,
   RIGHT: <Right width={8} height={12} />,

--- a/src/components/@common/Calendar/index.tsx
+++ b/src/components/@common/Calendar/index.tsx
@@ -2,11 +2,10 @@ import { GA } from '@/constants/GA';
 import { useGetMonthStatus } from '@/queries/Detail/useGetMonthStatus';
 import { useGroupDetail } from '@/queries/Group';
 import { dateState } from '@/store/dateState';
-import { userState } from '@/store/userState';
 import createCalendar from '@/utils/createCalendar';
 import { handleDate } from '@/utils/handleDate';
 import dayjs, { Dayjs } from 'dayjs';
-import { FC, useEffect, useLayoutEffect, useState } from 'react';
+import { FC, useLayoutEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { ARROW } from '../../../assets/icons/Arrow';
@@ -26,7 +25,6 @@ interface CalnedrProps {
 const Calendar: FC<CalnedrProps> = ({ cellType }) => {
   const today = dayjs();
 
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
   const [{ baseDate, startDate, endDate, mode }, setDateTestObj] = useRecoilState(dateState);
   const [showCreateDetailModal, setShowCreateDetailModal] = useState(false);
   const [calendarDate, setCalendarDate] = useState(baseDate);
@@ -41,6 +39,7 @@ const Calendar: FC<CalnedrProps> = ({ cellType }) => {
   const endDateOfMonth = dateToFormatting(dayjs(calendarDate).endOf('month'));
 
   const { data: status } = useGetMonthStatus(groupId, startDateOfMonth, endDateOfMonth);
+  const { data: group } = useGroupDetail(Number(groupId));
 
   const filterCorrectDateStatus = (date: Dayjs) => {
     const hasStatusOfDay = (status?.content.statusOfDay ?? {}).hasOwnProperty(getDate(date));
@@ -107,7 +106,7 @@ const Calendar: FC<CalnedrProps> = ({ cellType }) => {
               </Style.ArrowWrapper>
             </Style.ArrowBlock>
           </div>
-          {cellType === 'Tag' && isAdmin && (
+          {cellType === 'Tag' && group?.content.isAdmin && (
             <Button width="124px" color="black" onClick={handleShowCreateDetailModal} id={GA.ADD_LIST.BUTTON}>
               내역 추가하기
             </Button>

--- a/src/components/@common/Calendar/index.tsx
+++ b/src/components/@common/Calendar/index.tsx
@@ -76,13 +76,12 @@ const Calendar: FC<CalnedrProps> = ({ cellType }) => {
   };
 
   const goDetail = (date: Dayjs) => {
-    setDateTestObj((prev) => ({
-      ...prev,
-      baseDateTest: date,
+    setDateTestObj({
+      baseDate: date,
       startDate: date,
       endDate: date,
       mode: 'day',
-    }));
+    });
     navigate(`/group/${groupId}/book/detail`);
   };
 

--- a/src/components/DetailFine/DateController/index.tsx
+++ b/src/components/DetailFine/DateController/index.tsx
@@ -16,7 +16,6 @@ import FineBookCreateModal from '@/components/@common/Modal/FineBookModal/FineBo
 import { dateState } from '@/store/dateState';
 import useDateController from './hook/useDateController';
 import { DetailFilter } from '@/store/detailFilter';
-import { userState } from '@/store/userState';
 
 export const FILTER_BUTTON_LIST: { mode: FilterMode; text: string; id: string }[] = [
   { mode: 'month', text: '월간', id: GA.FILTER.MONTH },
@@ -29,7 +28,9 @@ type Props = {
 };
 
 const DateController = ({ setDetailFilter }: Props) => {
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  const { groupId } = useParams();
+  const { data: group } = useGroupDetail(Number(groupId));
+
   const dropDownRef = useRef<HTMLDivElement>(null);
   const initialAddModalState = useCheckLocationState();
 
@@ -105,7 +106,7 @@ const DateController = ({ setDetailFilter }: Props) => {
                 );
               })}
             </Style.FilterWrapper>
-            {isAdmin && (
+            {group?.content.isAdmin && (
               <Button color="black" width="124px" height="40px" onClick={handleAddModal} id="add_list">
                 내역 추가하기
               </Button>

--- a/src/components/DetailFine/DropDownWrapper/index.tsx
+++ b/src/components/DetailFine/DropDownWrapper/index.tsx
@@ -6,9 +6,8 @@ import { CircleButtonList, CircleDropButton } from '@/components/DetailFine';
 import * as Style from './styles';
 import { SelectedEventInfo } from '@/types/event';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
-import { userState } from '@/store/userState';
-import { useRecoilState } from 'recoil';
 import useSituationList from '@/hooks/useSituationList';
+import { useGroupDetail } from '@/queries/Group';
 
 interface Props {
   detail: SelectedEventInfo;
@@ -19,11 +18,12 @@ interface Props {
 const DropDownWrapper = ({ detail, openButtonListId, setOpenButtonListId }: Props) => {
   const { eventId, situation, nickname } = detail;
   const { groupId } = useParams();
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
 
+  const { data: group } = useGroupDetail(Number(groupId));
   const { data: myNickname } = useGetMyNikname(Number(groupId));
   const { convertSituationToText } = useSituationList(situation);
 
+  const isAdmin = group?.content.isAdmin;
   const isOwn = nickname === myNickname?.content.nickname;
   const isSelectedEvent = openButtonListId === eventId;
 

--- a/src/components/DetailFine/UserDetails/index.tsx
+++ b/src/components/DetailFine/UserDetails/index.tsx
@@ -15,9 +15,8 @@ import useConfirmModal from '@/hooks/useConfirmModal';
 import FineBookUpdateModal from '@/components/@common/Modal/FineBookModal/FineBookUpdateModal';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
 import { useSelectedContext } from '@/contexts/SelectedFineContext';
-import { userState } from '@/store/userState';
-import { useRecoilState } from 'recoil';
 import useSituationList, { SituationText } from '@/hooks/useSituationList';
+import { useGroupDetail } from '@/queries/Group';
 
 type Props = {
   select: SelectedEventInfo;
@@ -30,7 +29,6 @@ const REQUEST_BUTTON: { [key in Situation]: string } = {
   완납: '확인 완료',
 };
 
-
 const UserDetails = () => {
   const { selectedFine, setSelectedFine } = useSelectedContext('userDetails');
 
@@ -39,9 +37,9 @@ const UserDetails = () => {
   const hasSelectedInfo: boolean = eventId !== 0;
 
   const { groupId } = useParams();
+  const { data: group } = useGroupDetail(Number(groupId));
+  const isAdmin = group?.content.isAdmin;
 
-
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
 
   const handleUpdateModal = () => {

--- a/src/components/MemberManagement/MemberListItem/index.tsx
+++ b/src/components/MemberManagement/MemberListItem/index.tsx
@@ -4,10 +4,8 @@ import DropDown from '@/components/@common/DropDown';
 import { GA } from '@/constants/GA';
 import useConfirmModal from '@/hooks/useConfirmModal';
 import { useChangeAdmin, useGroupDetail } from '@/queries/Group';
-import { userState } from '@/store/userState';
 import { FC, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 import * as Style from './styles';
 
 interface MemberListItemProps {
@@ -21,7 +19,8 @@ const DropDonwList = [
 
 const MemberListItem: FC<MemberListItemProps> = ({ nickname }) => {
   const { groupId } = useParams();
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  const { data: group } = useGroupDetail(Number(groupId));
+  const isAdmin = group?.content.isAdmin;
 
   const [showDropDown, setShowDropDown] = useState(false);
   const [selectAction, setSelectAction] = useState('');

--- a/src/hooks/useSituationList.ts
+++ b/src/hooks/useSituationList.ts
@@ -1,6 +1,6 @@
-import { userState } from '@/store/userState';
+import { useGroupDetail } from '@/queries/Group';
 import { Situation } from '@/types/event';
-import { useRecoilState } from 'recoil';
+import { useParams } from 'react-router-dom';
 
 type ConfirmButtonText = '확인요청' | '확인필요' | '확인중';
 export type SituationText = Situation | ConfirmButtonText;
@@ -8,7 +8,9 @@ export type SituationText = Situation | ConfirmButtonText;
 const SITUATION_LIST: Situation[] = ['미납', '확인중', '완납'];
 
 const useSituationList = (situation: Situation) => {
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  const { groupId } = useParams();
+  const { data: group } = useGroupDetail(Number(groupId));
+  const isAdmin = group?.content.isAdmin;
 
   const adminStatusList: SituationText[] = [
     situation === '확인중' ? '확인필요' : situation,

--- a/src/layouts/Group/components/SideBar/index.tsx
+++ b/src/layouts/Group/components/SideBar/index.tsx
@@ -2,12 +2,10 @@ import { AdminModal } from '@/components/@common/Modal/GroupSettingModal/AdminMo
 import { UserModal } from '@/components/@common/Modal/GroupSettingModal/UserModal';
 import { GA } from '@/constants/GA';
 import { useGroupDetail } from '@/queries/Group';
-import { userState } from '@/store/userState';
 import React, { useEffect, useState } from 'react';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
-import { SYSTEM } from '../../../../assets/icons/System';
-import { USER } from '../../../../assets/icons/User';
+import { SYSTEM } from '@/assets/icons/System';
+import { USER } from '@/assets/icons/User';
 import * as Style from './styles';
 
 const GROUP_TAPS = [
@@ -25,7 +23,9 @@ const GroupSideBar = () => {
   const navigate = useNavigate();
   const { groupId } = param;
 
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  const { data: group } = useGroupDetail(Number(groupId));
+  const isAdmin = group?.content.isAdmin;
+
   const [showGroupSettingModal, setShowGroupSettingModal] = useState(false);
   const { data: groupData, isError } = useGroupDetail(Number(groupId));
 

--- a/src/pages/MemberManagement/index.tsx
+++ b/src/pages/MemberManagement/index.tsx
@@ -4,10 +4,8 @@ import MemberListItem from '@/components/MemberManagement/MemberListItem';
 import { GA } from '@/constants/GA';
 import { useGroupDetail, useParticipantList } from '@/queries/Group';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
-import { userState } from '@/store/userState';
 import { copyInvitationLink } from '@/utils/copyInvitationLink';
 import { useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 import * as Style from './styles';
 
 const MemberManagement = () => {
@@ -15,7 +13,11 @@ const MemberManagement = () => {
 
   const { data: participantList } = useParticipantList(Number(groupId));
   const { data: myNickname } = useGetMyNikname(Number(groupId));
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  // 혹시 이거 때문인가.. 데이터를 갈아 끼워줘도 recoil이 갈아끼워지지 않으니까..
+  // recoil로 관리를 하니까 사이드 이펙트가 발생하는구나
+  // 괜히 서버 상태는 tanstack-query로 캐시를 다루고 있으니까, optimistic update를 할 때에도 문제가 발생해
+  //
+  const { data: group } = useGroupDetail(Number(groupId));
 
   return (
     <>
@@ -31,9 +33,9 @@ const MemberManagement = () => {
           <Style.UserIcon>{USER.PERSON_XL}</Style.UserIcon>
           <span>{participantList?.content.adminNickname}</span>
           <Style.Tag>총무</Style.Tag>
-          {isAdmin && <Style.Tag>나</Style.Tag>}
+          {group?.content.isAdmin && <Style.Tag>나</Style.Tag>}
         </Style.UserContainer>
-        {myNickname && !isAdmin && (
+        {myNickname && !group?.content.isAdmin && (
           <Style.UserContainer>
             <Style.UserIcon>{USER.PERSON_XL}</Style.UserIcon>
             <div>{myNickname.content.nickname}</div>

--- a/src/pages/MemberManagement/index.tsx
+++ b/src/pages/MemberManagement/index.tsx
@@ -13,10 +13,14 @@ const MemberManagement = () => {
 
   const { data: participantList } = useParticipantList(Number(groupId));
   const { data: myNickname } = useGetMyNikname(Number(groupId));
-  // 혹시 이거 때문인가.. 데이터를 갈아 끼워줘도 recoil이 갈아끼워지지 않으니까..
-  // recoil로 관리를 하니까 사이드 이펙트가 발생하는구나
-  // 괜히 서버 상태는 tanstack-query로 캐시를 다루고 있으니까, optimistic update를 할 때에도 문제가 발생해
-  //
+  /**
+   * 혹시 이거 때문인가.. 데이터를 갈아 끼워줘도 recoil이 갈아끼워지지 않으니까..
+   * recoil로 관리를 하니까 사이드 이펙트가 발생하는구나
+   * 특히 optimistic update를 할 때, onMutate에서 낙관적인 데이터 넣어주고,
+   * 응답을 받고 나서는 제거해야 하는데 그럼 데이터를 넣을 때에도 setRecoilState를 해줘야 하고,
+   * 응답을 받고 나서도 onSettle에서 다시 한 번 업데이트를 해줘야 하니까 불편한게 많음
+   * => 서버 상태는 오직 tanstack-query 담당하게 하는 것이 맞음
+   */
   const { data: group } = useGroupDetail(Number(groupId));
 
   return (

--- a/src/pages/WholeCalendar/index.tsx
+++ b/src/pages/WholeCalendar/index.tsx
@@ -7,12 +7,12 @@ import { useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { Calendar } from '@/components/@common';
 import InviteModal from '@/components/@common/Modal/InviteModal';
-import { userState } from '@/store/userState';
 
 const WholeCalendar = () => {
   const [{ isFirstVisit }, setIsFirstVisit] = useRecoilState(firstVisitState);
   const [dateObj, setDateObj] = useRecoilState(dateState);
-  const [{ isAdmin }, setUser] = useRecoilState(userState);
+  const { groupId } = useParams();
+  const { data: group } = useGroupDetail(Number(groupId));
 
   const handleGroupInviteModal = () => {
     setIsFirstVisit((prev) => ({ ...prev, isFirstVisit: false }));
@@ -32,7 +32,7 @@ const WholeCalendar = () => {
   return (
     <>
       <Calendar cellType="Tag" />
-      {isAdmin && isFirstVisit && <InviteModal onClick={handleGroupInviteModal} />}
+      {group?.content.isAdmin && isFirstVisit && <InviteModal onClick={handleGroupInviteModal} />}
     </>
   );
 };

--- a/src/queries/Group/useChangeAdmin.ts
+++ b/src/queries/Group/useChangeAdmin.ts
@@ -16,7 +16,9 @@ export const useChangeAdmin = (groupId: number | undefined) => {
       const myNickname = queryClient.getQueryData<ServerResponse<GroupNickname>>(['myNickname', groupId]);
 
       if (prevParticipantList) {
-        const newList = prevParticipantList.content.nicknameList.filter((nickname) => nickname !== myNickname?.content.nickname);
+        const newList = prevParticipantList.content.nicknameList.filter(
+          (participantNickname) => participantNickname !== myNickname?.content.nickname && participantNickname !== nickname,
+        );
 
         queryClient.setQueryData<ServerResponse<ParticipantList>>(['participantList', groupId], {
           ...prevParticipantList,

--- a/src/queries/Group/useGroupDetail.ts
+++ b/src/queries/Group/useGroupDetail.ts
@@ -1,13 +1,6 @@
 import { getGroupDetail } from '@/api/Group';
-import { userState } from '@/store/userState';
 import { useQuery } from '@tanstack/react-query';
-import { useRecoilState } from 'recoil';
 
 export const useGroupDetail = (groupId: number | undefined) => {
-  const [user, setUser] = useRecoilState(userState);
-  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId), {
-    onSuccess(data) {
-      setUser((prev) => ({ ...prev, isAdmin: data.content.isAdmin }));
-    },
-  });
+  return useQuery(['groupDetail', groupId], () => getGroupDetail(groupId));
 };

--- a/src/store/userState.ts
+++ b/src/store/userState.ts
@@ -7,7 +7,6 @@ const { persistAtom } = recoilPersist({
 export interface UserState {
   email: string | null;
   userId: number | null;
-  isAdmin?: boolean;
 }
 
 export const userState = atom<UserState>({
@@ -15,7 +14,6 @@ export const userState = atom<UserState>({
   default: {
     email: null,
     userId: null,
-    isAdmin: false,
   },
   effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## 👀 개요

- 멤버리스트 UI버그 수정 #102 
- 한글을 영어로 인식하고 번역해서 이상한 워딩으로 변경되는 현상 수정 #127 
- recoil에서 관리하던 isAdmin 제거 b769141cc773b8ddfa64f9ac85eed7c947f8653b
- dropdown arrow 색상값 변경으로 인한 수정
- 달력을 클릭해도 변경되지 않는 현상 수정

<br />

## 🧑‍💻 구현 디테일 및 화면

- 멤버리스트 UI버그
  - 새로 바뀌는 총무에 대한 멤버 필터링이 걸려있지 않아 UI오류 발생
  - isAdmin을 reocil로 관리하고  있었기에, optimistic 업데이트를 해도, isAdmin까지는 업데이트 하지 않았기에 어드민 변경 성공 응답을 받고 나서야 admin을 변경시켜주는 오류 발생 
  - 새로운 총무 필터링 및 isAdmin recoil제거 후 tanstack-query로 관리하도록 다시 변경

- 달력 클릭 시 날짜가 변경되지 않는 현상
  - baseDate가 아닌 baseDateTest가 변경되고 있었음

<br />

## ✔️ 참고 사항 및 자료
- 오탈자는 타입 검사 시에 왜 검출되지 않았을까요..? 구조적 타이핑이어도, 변수에 할당하는 게 아니라 객체를 바로 전달하면 아래 사진처럼 타입 검사가 진행 되어야 할텐데... 
<img width="585" alt="image" src="https://github.com/so-sim/front/assets/95389265/16fd4638-01f4-4e16-b77e-723d5c7daa80">

- 멤버리스트 UI버그였던 것.
https://github.com/so-sim/front/assets/95389265/db554fb4-6986-486c-a88c-10d603384393