### PR TITLE
내역 추가(수정) 모달 기능  추가 및 버그 수정

### DIFF
--- a/src/components/@common/Calendar/index.tsx
+++ b/src/components/@common/Calendar/index.tsx
@@ -79,7 +79,7 @@ const Calendar: FC<CalnedrProps> = ({ cellType }) => {
   const goDetail = (date: Dayjs) => {
     setDateTestObj((prev) => ({
       ...prev,
-      baseDateTest: date,
+      baseDate: date,
       startDate: date,
       endDate: date,
       mode: 'day',

--- a/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
+++ b/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useEffect, useReducer } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { useCreateDetail } from '@/queries/Detail';
@@ -9,6 +9,7 @@ import Modal from '@/components/@common/Modal';
 import { SYSTEM } from '@/assets/icons/System';
 import { dateState } from '@/store/dateState';
 import { initialSelectData } from '@/pages/FineBook/DetailFine';
+import { SelectedEventInfo } from '@/types/event';
 
 import { selectedDataReducer } from '../reducer/selectedDataReducer';
 import { pushDataLayer } from '@/utils/pushDataLayer';
@@ -21,12 +22,30 @@ interface Props {
   modalHandler: () => void;
 }
 
+const doNotInitProperty = <K extends keyof SelectedEventInfo>(...arg: K[]) => {
+  const newObj: Partial<SelectedEventInfo> = {};
+
+  arg.forEach((key) => {
+    newObj[key] = initialSelectData[key];
+  });
+
+  return newObj;
+};
+
 const FineBookCreateModal = ({ modalHandler }: Props) => {
-  const [_, setDateState] = useRecoilState(dateState);
+  const [calendarState, setDateState] = useRecoilState(dateState);
   const { groupId } = useParams();
   const navigate = useNavigate();
 
   const [selectData, dispatch] = useReducer(selectedDataReducer, initialSelectData);
+
+  useEffect(() => {
+    console.log(calendarState);
+    if (calendarState.mode === 'day') {
+      const date = calendarState.baseDate.format('YYYY.MM.DD');
+      dispatch({ type: 'DATE', date });
+    }
+  }, []);
 
   const createDetail = (type: 'continue' | 'save') => {
     create(
@@ -44,7 +63,7 @@ const FineBookCreateModal = ({ modalHandler }: Props) => {
 
           if (type === 'continue') {
             navigate(`/group/${groupId}/book/detail`, { state: true });
-            dispatch({ type: 'INIT', initialData: initialSelectData });
+            dispatch({ type: 'INIT', initialData: doNotInitProperty('nickname', 'date') });
           } else {
             navigate(`/group/${groupId}/book/detail`);
             modalHandler();

--- a/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
+++ b/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
@@ -40,7 +40,6 @@ const FineBookCreateModal = ({ modalHandler }: Props) => {
   const [selectData, dispatch] = useReducer(selectedDataReducer, initialSelectData);
 
   useEffect(() => {
-    console.log(calendarState);
     if (calendarState.mode === 'day') {
       const date = dayjs(calendarState.baseDate).format('YYYY.MM.DD');
       dispatch({ type: 'DATE', date });

--- a/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
+++ b/src/components/@common/Modal/FineBookModal/FineBookCreateModal/index.tsx
@@ -42,7 +42,7 @@ const FineBookCreateModal = ({ modalHandler }: Props) => {
   useEffect(() => {
     console.log(calendarState);
     if (calendarState.mode === 'day') {
-      const date = calendarState.baseDate.format('YYYY.MM.DD');
+      const date = dayjs(calendarState.baseDate).format('YYYY.MM.DD');
       dispatch({ type: 'DATE', date });
     }
   }, []);
@@ -63,7 +63,7 @@ const FineBookCreateModal = ({ modalHandler }: Props) => {
 
           if (type === 'continue') {
             navigate(`/group/${groupId}/book/detail`, { state: true });
-            dispatch({ type: 'INIT', initialData: doNotInitProperty('nickname', 'date') });
+            dispatch({ type: 'INIT', initialData: doNotInitProperty('nickname', 'memo') });
           } else {
             navigate(`/group/${groupId}/book/detail`);
             modalHandler();

--- a/src/components/@common/Modal/FineBookModal/FormFileds/index.tsx
+++ b/src/components/@common/Modal/FineBookModal/FormFileds/index.tsx
@@ -58,8 +58,6 @@ const FormFileds = ({ selectData, dispatch }: Props) => {
 
   const onChangeMemo = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     dispatch({ type: 'MEMO', memo: e.target.value });
-
-
   };
 
   return (
@@ -97,7 +95,7 @@ const FormFileds = ({ selectData, dispatch }: Props) => {
         </Label>
       </Style.Row>
       <Label title="메모" width="32px" margin="0px">
-        <Style.TextArea maxLength={65} onChange={onChangeMemo} defaultValue={selectData.memo} placeholder="내용을 입력해주세요." />
+        <Style.TextArea maxLength={65} onChange={onChangeMemo} defaultValue={selectData.memo} value={selectData.memo} placeholder="내용을 입력해주세요." />
         <Style.Length>{selectData.memo.length}/65</Style.Length>
       </Label>
     </>

--- a/src/components/@common/Modal/FineBookModal/FormFileds/index.tsx
+++ b/src/components/@common/Modal/FineBookModal/FormFileds/index.tsx
@@ -23,7 +23,6 @@ type Props = {
 const FormFileds = ({ selectData, dispatch }: Props) => {
   const { groupId } = useParams();
   const { data: participants } = useParticipantList(Number(groupId));
-  console.log(selectData);
 
   const { dropdownList, convertSituationToText, convertTextToSituation } = useSituationList(selectData.situation);
 
@@ -95,7 +94,7 @@ const FormFileds = ({ selectData, dispatch }: Props) => {
         </Label>
       </Style.Row>
       <Label title="메모" width="32px" margin="0px">
-        <Style.TextArea maxLength={65} onChange={onChangeMemo} defaultValue={selectData.memo} value={selectData.memo} placeholder="내용을 입력해주세요." />
+        <Style.TextArea maxLength={65} onChange={onChangeMemo} value={selectData.memo} placeholder="내용을 입력해주세요." />
         <Style.Length>{selectData.memo.length}/65</Style.Length>
       </Label>
     </>

--- a/src/components/@common/Modal/FineBookModal/reducer/selectedDataReducer.ts
+++ b/src/components/@common/Modal/FineBookModal/reducer/selectedDataReducer.ts
@@ -3,7 +3,7 @@ import { Situation } from '@/types/event';
 import { convertFromPriceFormat } from '@/utils/convertPriceFormat';
 
 type Action =
-  | { type: 'INIT'; initialData: SelectedEventInfo }
+  | { type: 'INIT'; initialData: Partial<SelectedEventInfo> }
   | { type: 'NICKNAME'; nickname: string }
   | { type: 'SITUATION'; situation: Situation }
   | { type: 'AMOUNT'; amount: string }
@@ -16,7 +16,7 @@ export const selectedDataReducer = (state: SelectedEventInfo, actions: Action) =
   switch (actions.type) {
     case 'INIT':
       const { initialData } = actions;
-      return { ...state, initialData };
+      return { ...state, ...initialData };
     case 'NICKNAME':
       const { nickname } = actions;
       return { ...state, nickname };


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #121 
- 간단한 설명

-->
내역 추가(수정) 모달 기능  추가 및 버그 수정

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 일간 상태에서 내역 추가 시 선택 날짜가 유지되는 기능 추가
- 계속 추가 시 팀원과 메모는 초기화되는 기능 추가
- 기존에 reducer 초기화 되지않고  { ...prev, initialstate: { 데이터 } } 로 저장되는 버그 수정


<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

- doNotInitProperty 에서 고민이 많았어서 고안되었던 함수를 기록차 작성해봅니다.
``` javascript
let obj={a:1,b:2,c:3,d:4}
function func(…args){
return args.reduce((acc,ele)=>{
    if(obj[ele]) delete acc[ele]
    return acc 
},{…obj})
}

const func = (...args) => Object.fromEntries(Object.entries(data).filter(([k])=> !args.includes(k)))

function func(…args) {
    const obj= {…initialSelectData};
    args.forEach(key => delete obj[key])
    return obj
}


function func(…args){
  let result={}
  for(let key in obj){
      if(!args.includes(key)){
          result[key]=obj[key]
      }
  }
  return result;
}

```

- key를 동적으로 사용할 수는 있지만(computed property) , 배열 형식 key에서는 해당 방식은 동적으로 사용이 불가능한 것 같다
- Typescript 공부가 조금 필요하다는걸 깨달았습니다. 
