### PR TITLE
Fix: 닉네임에 이모지 포함되지 않도록 변경 및 버그 수정

### DIFF
--- a/src/components/@common/Input/index.tsx
+++ b/src/components/@common/Input/index.tsx
@@ -14,7 +14,9 @@ interface InputProps<T = any> {
 
 const Input = ({ onChange, value, placeholder = '', maxLength = 10, errorText = '', setError, title }: InputProps) => {
   const onChangeData = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(e.target.value);
+    if (e.target.value.length <= maxLength) {
+      onChange(e.target.value);
+    }
     if (setError) {
       setError(title, checkCountChar(e.target.value));
     }
@@ -22,7 +24,14 @@ const Input = ({ onChange, value, placeholder = '', maxLength = 10, errorText = 
 
   return (
     <>
-      <Style.Input type="text" placeholder={placeholder} isValid={errorText === '' ? true : false} value={value} onChange={onChangeData} maxLength={maxLength} />
+      <Style.Input
+        type="text" //
+        placeholder={placeholder}
+        isValid={errorText === ''}
+        value={value}
+        onChange={onChangeData}
+        maxLength={maxLength}
+      />
       <Style.Phrase>
         <Style.ErrorText>{errorText}</Style.ErrorText>
         <Style.Length>

--- a/src/components/@common/Input/index.tsx
+++ b/src/components/@common/Input/index.tsx
@@ -21,7 +21,7 @@ const Input = ({ onChange, value, placeholder = '', maxLength = 10, errorText = 
     }
 
     if (title === 'nickname' && setError) {
-      checkEmoji(text) ? setError(title, '이모지가 포함되면 안 됨') : setError(title, checkCountChar(text));
+      checkEmoji(text) ? setError(title, '한글/영문/숫자/특수문자만 입력해주세요.') : setError(title, checkCountChar(text));
       return;
     }
 

--- a/src/components/@common/Input/index.tsx
+++ b/src/components/@common/Input/index.tsx
@@ -17,6 +17,14 @@ const Input = ({ onChange, value, placeholder = '', maxLength = 10, errorText = 
     if (e.target.value.length <= maxLength) {
       onChange(e.target.value);
     }
+    if (title === 'nickname' && setError) {
+      const emojiRegExp = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\s]+$/;
+      const text = e.target.value;
+
+      const result = emojiRegExp.test(text);
+      !result && text !== '' ? setError(title, '이모지가 포함되면 안 됨') : setError(title, checkCountChar(text));
+      return;
+    }
     if (setError) {
       setError(title, checkCountChar(e.target.value));
     }

--- a/src/components/@common/Input/index.tsx
+++ b/src/components/@common/Input/index.tsx
@@ -1,4 +1,4 @@
-import { checkCountChar } from '@/utils/validation';
+import { checkCountChar, checkEmoji } from '@/utils/validation';
 import React, { useEffect } from 'react';
 import * as Style from './styles';
 
@@ -14,19 +14,19 @@ interface InputProps<T = any> {
 
 const Input = ({ onChange, value, placeholder = '', maxLength = 10, errorText = '', setError, title }: InputProps) => {
   const onChangeData = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value.length <= maxLength) {
-      onChange(e.target.value);
-    }
-    if (title === 'nickname' && setError) {
-      const emojiRegExp = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\s]+$/;
-      const text = e.target.value;
+    const text = e.target.value;
 
-      const result = emojiRegExp.test(text);
-      !result && text !== '' ? setError(title, '이모지가 포함되면 안 됨') : setError(title, checkCountChar(text));
+    if (text.length <= maxLength) {
+      onChange(text);
+    }
+
+    if (title === 'nickname' && setError) {
+      checkEmoji(text) ? setError(title, '이모지가 포함되면 안 됨') : setError(title, checkCountChar(text));
       return;
     }
+
     if (setError) {
-      setError(title, checkCountChar(e.target.value));
+      setError(title, checkCountChar(text));
     }
   };
 

--- a/src/components/@common/Modal/GroupSettingModal/UserModal/index.tsx
+++ b/src/components/@common/Modal/GroupSettingModal/UserModal/index.tsx
@@ -57,7 +57,14 @@ export const UserModal: FC<ModalHandlerProps> = ({ modalHandler }) => {
           <Style.SubTitle>사용자 설정</Style.SubTitle>
           <Style.InputContainer>
             <Label title="내 이름" flexDirection="column">
-              <Input value={myName} errorText={isError.nickname} onChange={setMyName} maxLength={20} setError={setError} title="nickname" />
+              <Input
+                value={myName} //
+                errorText={isError.nickname}
+                onChange={setMyName}
+                maxLength={15}
+                setError={setError}
+                title="nickname"
+              />
             </Label>
             <Label title="모임 탈퇴" flexDirection="column" />
             <Style.WithDrwal>

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -32,3 +32,12 @@ export const checkFormIsValid = (selectData: Omit<EventInfoTest, 'groupId'>): bo
 
   return true;
 };
+
+/**
+ * 이모지 포함 여부만 체크하는 함수
+ * text가 빈 문자열일 경우에는 걸러주면 안 되기에 text !== ''옵션 추가
+ */
+export const checkEmoji = (text: string) => {
+  const regExp = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\s]+$/;
+  return !regExp.test(text) && text !== '';
+};


### PR DESCRIPTION
## 👀 개요

- 팀원 검색이 도입될 시, 이모지로 검색할 방법이 없기 때문에 닉네임에서 이모지 거르는 필터 적용 #135
- 닉네임 수정 모달에 maxLength가 20이고, maxLength를 넘어서 출력되는 현상

<br />

## 🧑‍💻 구현 디테일 및 화면
 
- maxLength가 적용되는 Input 컴포넌트에 조건 추가 4342dea42b96cb8e8b441c778dbadc8e9222b43b
- 필터링 하는 함수의 이모지 정규표현식 추가 (checkEmoji)
- 이모지 에러메세지 추가

<br />

## ✔️ 참고 사항 및 자료


- https://www.notion.so/4069917d91934f979b4ec6989dddea03?pvs=4
