### PR TITLE
Feat: 캘린더 비지니스로직 분리 및  모바일 캘린더, 멤버관리 생성

### DIFF
--- a/src/assets/icons/System/ToolTip.svg
+++ b/src/assets/icons/System/ToolTip.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group">
+<path id="Vector" d="M11 7H13V9H11V7ZM11 11H13V17H11V11ZM12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z" fill="#3C3C3C"/>
+</g>
+</svg>

--- a/src/assets/icons/System/index.tsx
+++ b/src/assets/icons/System/index.tsx
@@ -10,6 +10,7 @@ import Dots from './Dots.svg';
 import PreParing from './PreParing.svg';
 import Search from './Search.svg';
 import Menu from './Menu.svg';
+import ToolTip from './ToolTip.svg';
 
 export const SYSTEM = {
   ARTICLE: <Article />,
@@ -32,4 +33,6 @@ export const SYSTEM = {
   SEARCH_BLACK: <Search fill="#3C3C3C" width={24} height={24} />,
   SEARCH_GRAY: <Search fill="#9C9C9C" width={24} height={24} />,
   SEARCH_GRAY_LG: <Search fill="#E3E4E5" width={48} height={48} />,
+  TOOLTIP: <ToolTip width={24} height={24} />,
+  PLUS_WHITE: <Plus width={24} height={24} />,
 };

--- a/src/components/@common/Calendar/DateCellWithMark/index.tsx
+++ b/src/components/@common/Calendar/DateCellWithMark/index.tsx
@@ -1,4 +1,4 @@
-import { PayMentTpyeCountMap } from '@/types/event';
+import { PayMentTypeCountMap } from '@/types/event';
 import { handleDate } from '@/utils/handleDate';
 import { Dayjs } from 'dayjs';
 import { FC } from 'react';
@@ -15,7 +15,7 @@ interface DateCellWithMarkProps {
   isToday: (date: Dayjs) => boolean;
   isSelectedDate: (date: Dayjs) => boolean;
   isSelectedPeriod: boolean;
-  status: PayMentTpyeCountMap | undefined;
+  status: PayMentTypeCountMap | undefined;
 }
 
 const DateCellWithMark: FC<DateCellWithMarkProps> = ({ date, isCurrentMonth, isToday, isSelectedDate, isSelectedPeriod, status, startDate, endDate, mode }) => {

--- a/src/components/@common/Calendar/DateCellWithTag/index.tsx
+++ b/src/components/@common/Calendar/DateCellWithTag/index.tsx
@@ -1,4 +1,4 @@
-import { PayMentTpyeCountMap } from '@/types/event';
+import { PayMentTypeCountMap } from '@/types/event';
 import { Dayjs } from 'dayjs';
 import { FC } from 'react';
 import { MARK } from '@/assets/icons/Mark';
@@ -9,7 +9,7 @@ interface DateCellWitTagProps {
   isCurrentMonth: (date: Dayjs) => boolean;
   isToday: (date: Dayjs) => boolean;
   isSelectedDate: (date: Dayjs) => boolean;
-  status: PayMentTpyeCountMap | undefined;
+  status: PayMentTypeCountMap | undefined;
 }
 
 const DateCellWithTag: FC<DateCellWitTagProps> = ({ date, isCurrentMonth, isToday, isSelectedDate, status }) => {

--- a/src/hooks/Calendar/useCalendarState.ts
+++ b/src/hooks/Calendar/useCalendarState.ts
@@ -1,0 +1,37 @@
+import { dateState } from '@/store/dateState';
+import createCalendar from '@/utils/createCalendar';
+import { handleDate } from '@/utils/handleDate';
+import dayjs from 'dayjs';
+import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+type CreateCalendarHook = {
+  calendarDate: dayjs.Dayjs;
+  setCalendarDate: React.Dispatch<React.SetStateAction<dayjs.Dayjs>>;
+  increaseMonth: () => void;
+  decreaseMonth: () => void;
+};
+
+const useCalendarState = (): CreateCalendarHook => {
+  const { addMonth, subMonth } = handleDate;
+
+  const [{ baseDate, startDate, endDate, mode }, setDateTestObj] = useRecoilState(dateState);
+
+  const [calendarDate, setCalendarDate] = useState(baseDate);
+
+  const increaseMonth = () => {
+    setCalendarDate(addMonth(calendarDate));
+  };
+  const decreaseMonth = () => {
+    setCalendarDate(subMonth(calendarDate));
+  };
+
+  return {
+    calendarDate,
+    setCalendarDate,
+    increaseMonth,
+    decreaseMonth,
+  };
+};
+
+export default useCalendarState;

--- a/src/hooks/Calendar/useCalendarStatus.ts
+++ b/src/hooks/Calendar/useCalendarStatus.ts
@@ -1,0 +1,61 @@
+import { useGetMonthStatus } from '@/queries/Detail/useGetMonthStatus';
+import { MonthStatus } from '@/types/event';
+import { ServerResponse } from '@/types/serverResponse';
+import { handleDate } from '@/utils/handleDate';
+import dayjs, { Dayjs } from 'dayjs';
+import { PayMentTypeCountMap } from '@/types/event';
+import { dateState } from '@/store/dateState';
+import { useRecoilState } from 'recoil';
+import createCalendar from '@/utils/createCalendar';
+
+type CalendarStatusHook = {
+  monthList: dayjs.Dayjs[][];
+  filterCorrectDateStatus: (date: Dayjs) => PayMentTypeCountMap | undefined;
+  isCurrentMonth: (date: Dayjs) => boolean;
+  isToday: (date: Dayjs) => boolean;
+  isSelectedDate: (date: Dayjs) => boolean;
+};
+
+const useCalendarStatus = (calendarDate: dayjs.Dayjs, groupId: string | undefined): CalendarStatusHook => {
+  const today = dayjs();
+
+  const [{ baseDate, startDate, endDate, mode }, setDateTestObj] = useRecoilState(dateState);
+
+  const { dateToFormatting, getMonth, getDate, dateToUnixTime } = handleDate;
+
+  const monthList = createCalendar(dayjs(calendarDate));
+
+  const startDateOfMonth = dateToFormatting(dayjs(calendarDate).startOf('month'));
+  const endDateOfMonth = dateToFormatting(dayjs(calendarDate).endOf('month'));
+
+  const { data: status } = useGetMonthStatus(groupId, startDateOfMonth, endDateOfMonth);
+
+  const filterCorrectDateStatus = (date: Dayjs) => {
+    const hasStatusOfDay = (status?.content.statusOfDay ?? {}).hasOwnProperty(getDate(date));
+
+    if (hasStatusOfDay) return status?.content.statusOfDay[getDate(date)];
+  };
+
+  const isCurrentMonth = (date: Dayjs) => {
+    return date.month() === getMonth(calendarDate);
+  };
+
+  const isToday = (date: Dayjs) => {
+    return dateToFormatting(date) === dateToFormatting(today);
+  };
+
+  const isSelectedDate = (date: Dayjs) => {
+    if (mode !== 'day') return false;
+    return dateToFormatting(startDate) === dateToFormatting(date);
+  };
+
+  return {
+    monthList,
+    filterCorrectDateStatus,
+    isCurrentMonth,
+    isToday,
+    isSelectedDate,
+  };
+};
+
+export default useCalendarStatus;

--- a/src/hooks/Member/useMemberManageMent.ts
+++ b/src/hooks/Member/useMemberManageMent.ts
@@ -1,0 +1,28 @@
+import { useGroupDetail, useParticipantList } from '@/queries/Group';
+import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
+import { useParams } from 'react-router-dom';
+
+const useMemberManageMent = () => {
+  const { groupId } = useParams();
+
+  const { data: participantList } = useParticipantList(Number(groupId));
+  const { data: myNickname } = useGetMyNikname(Number(groupId));
+  /**
+   * 혹시 이거 때문인가.. 데이터를 갈아 끼워줘도 recoil이 갈아끼워지지 않으니까..
+   * recoil로 관리를 하니까 사이드 이펙트가 발생하는구나
+   * 특히 optimistic update를 할 때, onMutate에서 낙관적인 데이터 넣어주고,
+   * 응답을 받고 나서는 제거해야 하는데 그럼 데이터를 넣을 때에도 setRecoilState를 해줘야 하고,
+   * 응답을 받고 나서도 onSettle에서 다시 한 번 업데이트를 해줘야 하니까 불편한게 많음
+   * => 서버 상태는 오직 tanstack-query 담당하게 하는 것이 맞음
+   */
+  const { data: group } = useGroupDetail(Number(groupId));
+
+  return {
+    groupId,
+    participantList,
+    myNickname,
+    group,
+  };
+};
+
+export default useMemberManageMent;

--- a/src/m-pages/MobileCalendar/index.tsx
+++ b/src/m-pages/MobileCalendar/index.tsx
@@ -1,0 +1,72 @@
+import { ARROW } from '@/assets/icons/Arrow';
+import { MARK } from '@/assets/icons/Mark';
+import { SYSTEM } from '@/assets/icons/System';
+import { GA } from '@/constants/GA';
+import useCalendarState from '@/hooks/Calendar/useCalendarState';
+import useCalendarStatus from '@/hooks/Calendar/useCalendarStatus';
+import { dateState } from '@/store/dateState';
+import dayjs from 'dayjs';
+import { useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+
+import * as Style from './styles';
+
+const WEEKDATE = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// 해당 부분 레이아웃 적용시키고,  기기에 따라서 높이가 반응형으로 대응을 해줘야할지 말지.. 고민
+const MobileCalendar = () => {
+  const { groupId } = useParams();
+  const [{ baseDate, startDate, endDate, mode }, setDateTestObj] = useRecoilState(dateState);
+
+  const { calendarDate, setCalendarDate, increaseMonth, decreaseMonth } = useCalendarState();
+  const { monthList, filterCorrectDateStatus, isCurrentMonth, isToday, isSelectedDate } = useCalendarStatus(calendarDate, groupId);
+
+  return (
+    <Style.Container>
+      <Style.DateControllerWrapper>
+        <Style.DateText>{dayjs(calendarDate).format('YYYY년 MM월')}</Style.DateText>
+        <Style.ArrowBlock id={GA.CALENDAR_SKIP.ALL}>
+          <Style.ArrowWrapper onClick={decreaseMonth} id={GA.CALENDAR_SKIP.LEFT}>
+            {ARROW.LEFT}
+          </Style.ArrowWrapper>
+          <Style.ArrowWrapper onClick={increaseMonth} id={GA.CALENDAR_SKIP.RIGHT}>
+            {ARROW.RIGHT}
+          </Style.ArrowWrapper>
+        </Style.ArrowBlock>
+        <Style.ToolTipIconWrapper>{SYSTEM.TOOLTIP}</Style.ToolTipIconWrapper>
+      </Style.DateControllerWrapper>
+
+      <Style.DayOfTheWeekWrapper>
+        {WEEKDATE.map((date) => (
+          <Style.DayOfTheWeekText key={date}>{date}</Style.DayOfTheWeekText>
+        ))}
+      </Style.DayOfTheWeekWrapper>
+      <Style.CalendarWrapper $length={monthList.length}>
+        {monthList.map((week, index) => (
+          <Style.WeekWrapper key={index}>
+            {week.map((date) => {
+              const status = filterCorrectDateStatus(date);
+              return (
+                <Style.DateWrapper>
+                  <Style.DateTitle>{date.date()}</Style.DateTitle>
+                  <div>
+                    {status && isCurrentMonth(date) && (
+                      <>
+                        {status['완납'] && !status['확인중'] && !status['미납'] ? <span>{MARK.BLUE}</span> : null}
+                        {status['확인중'] ? <span>{MARK.YELLOW}</span> : null}
+                        {status['미납'] ? <span>{MARK.RED}</span> : null}
+                      </>
+                    )}
+                  </div>
+                </Style.DateWrapper>
+              );
+            })}
+          </Style.WeekWrapper>
+        ))}
+      </Style.CalendarWrapper>
+      <Style.AddIconWrapper>{SYSTEM.PLUS_WHITE}</Style.AddIconWrapper>
+    </Style.Container>
+  );
+};
+
+export default MobileCalendar;

--- a/src/m-pages/MobileCalendar/index.tsx
+++ b/src/m-pages/MobileCalendar/index.tsx
@@ -46,8 +46,9 @@ const MobileCalendar = () => {
           <Style.WeekWrapper key={index}>
             {week.map((date) => {
               const status = filterCorrectDateStatus(date);
+              // 컴포넌트 분리 및 라우팅 연결 필요
               return (
-                <Style.DateWrapper>
+                <Style.DateWrapper key={index + date.date()}>
                   <Style.DateTitle>{date.date()}</Style.DateTitle>
                   <div>
                     {status && isCurrentMonth(date) && (
@@ -65,6 +66,7 @@ const MobileCalendar = () => {
         ))}
       </Style.CalendarWrapper>
       <Style.AddIconWrapper>{SYSTEM.PLUS_WHITE}</Style.AddIconWrapper>
+      {/* 내역 추가 페이지로 라우팅 */}
     </Style.Container>
   );
 };

--- a/src/m-pages/MobileCalendar/styles.ts
+++ b/src/m-pages/MobileCalendar/styles.ts
@@ -1,0 +1,104 @@
+import styled from '@emotion/styled';
+
+// 전체에 100vh를 가진 flex를 주고  마지막 calendar에만 flex1 주면 해결되긴함 (기기별 높이 반응형을 고려할 때 )
+
+export const Container = styled.div`
+  position: relative;
+
+  height: 100vh;
+  padding-top: 1.375rem;
+`;
+
+export const DateControllerWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const DateText = styled.div`
+  margin-right: 12px;
+  white-space: nowrap;
+  ${({ theme }) => theme.font.subhead_03}
+`;
+
+export const ArrowBlock = styled.div`
+  display: flex;
+`;
+
+export const ArrowWrapper = styled.button`
+  display: flex;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 2px solid ${({ theme }) => theme.colors.neutral_400_b};
+  &:first-of-type {
+    border-right: none;
+  }
+  &:hover {
+    background: ${({ theme }) => theme.colors.neutral_200_b};
+  }
+`;
+
+export const ToolTipIconWrapper = styled.div`
+  margin-left: auto;
+`;
+
+export const DayOfTheWeekWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(48px, 1fr));
+  margin: 0.5rem 0;
+`;
+
+export const DayOfTheWeekText = styled.p`
+  padding: 0.5rem 0.675rem;
+
+  text-align: center;
+
+  ${({ theme }) => theme.font.subhead_01};
+  color: ${({ theme }) => theme.colors.secondary_900};
+`;
+
+export const CalendarWrapper = styled.div<{ $length: number }>`
+  display: grid;
+  grid-template-rows: ${(props) => `repeat(${props.$length},minmax(80px,1fr))`};
+`;
+
+export const WeekWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(48px, 1fr));
+  border-top: 2px solid ${({ theme }) => theme.colors.neutral_200_b};
+`;
+
+export const DateWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  padding: 0.75rem 0.25rem;
+  text-align: center;
+`;
+
+export const DateTitle = styled.p`
+  ${({ theme }) => theme.font.subhead_02};
+  color: ${({ theme }) => theme.colors.secondary_900};
+`;
+
+export const AddIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  bottom: 2rem;
+  right: 1rem;
+
+  width: 3.25rem;
+  height: 3.25rem;
+
+  border: 2px solid ${({ theme }) => theme.colors.primary_400};
+  border-radius: 999px;
+
+  background-color: ${({ theme }) => theme.colors.primary_500};
+  color: white;
+`;

--- a/src/m-pages/MobileMemberManagement/index.tsx
+++ b/src/m-pages/MobileMemberManagement/index.tsx
@@ -1,0 +1,58 @@
+import { LOGO } from '@/assets/icons/Logo';
+import { SYSTEM } from '@/assets/icons/System';
+import { USER } from '@/assets/icons/User';
+import MemberListItem from '@/components/MemberManagement/MemberListItem';
+import { GA } from '@/constants/GA';
+import useMemberManageMent from '@/hooks/Member/useMemberManageMent';
+import MobileLayout from '@/layouts/Mobile';
+import MobileHeader from '@/layouts/Mobile/components/MobileHeader';
+import MobileSideBar from '@/layouts/Mobile/components/MobileSideBar';
+import { copyInvitationLink } from '@/utils/copyInvitationLink';
+import { useState } from 'react';
+import * as Style from './styles';
+
+const MobileMemberManagement = () => {
+  const [openSideBar, setOpenSideBar] = useState(false);
+
+  const sideBarHandler = () => {
+    setOpenSideBar((prev) => !prev);
+  };
+
+  const { groupId, participantList, myNickname, group } = useMemberManageMent();
+
+  return (
+    <MobileLayout>
+      <MobileHeader left={{ onClick: sideBarHandler, icon: SYSTEM.MENU }} title={LOGO.XS} hasAuth />
+      <Style.Container>
+        <Style.Title>
+          <h2>멤버 관리</h2>
+          <Style.ButtonFlex onClick={() => copyInvitationLink(Number(groupId))} id={GA.INVITATION.MEMBER}>
+            {SYSTEM.LINK_BLACK}
+            <span>초대링크 복사</span>
+          </Style.ButtonFlex>
+        </Style.Title>
+        <Style.UserContainer>
+          <Style.UserIcon>{USER.PERSON_XL}</Style.UserIcon>
+          <span>{participantList?.content.adminNickname}</span>
+          <Style.Tag>총무</Style.Tag>
+          {group?.content.isAdmin && <Style.Tag>나</Style.Tag>}
+        </Style.UserContainer>
+        {myNickname && !group?.content.isAdmin && (
+          <Style.UserContainer>
+            <Style.UserIcon>{USER.PERSON_XL}</Style.UserIcon>
+            <div>{myNickname.content.nickname}</div>
+            <Style.Tag>나</Style.Tag>
+          </Style.UserContainer>
+        )}
+        {participantList?.content.nicknameList.map((nickname) => {
+          if (nickname !== myNickname?.content.nickname) {
+            return <MemberListItem nickname={nickname} key={nickname} />;
+          }
+        })}
+      </Style.Container>
+      {openSideBar && <MobileSideBar openSideBar={openSideBar} sideBarHandler={sideBarHandler} />}
+    </MobileLayout>
+  );
+};
+
+export default MobileMemberManagement;

--- a/src/m-pages/MobileMemberManagement/styles.ts
+++ b/src/m-pages/MobileMemberManagement/styles.ts
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  padding-top: 48px;
+  border-width: 2px;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.colors.neutral_300_b};
+  border-top: none;
+  border-bottom: none;
+`;
+
+export const Title = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  h2 {
+    font-size: 28px;
+    color: ${({ theme }) => theme.colors.secondary_900};
+    ${({ theme }) => theme.font.headline};
+  }
+`;
+
+export const Flex = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const ButtonFlex = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  ${({ theme }) => theme.font.subhead_02}
+  color:${({ theme }) => theme.colors.secondary_900};
+  height: 32px;
+  padding: 4px 12px;
+  gap: 4px;
+  background-color: ${({ theme }) => theme.colors.neutral_200_b};
+  border: 2px solid ${({ theme }) => theme.colors.neutral_400_b};
+  border-radius: 4px;
+`;
+
+export const UserContainer = styled.div`
+  padding: 14px 32px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral_300_b};
+  ${({ theme }) => theme.font.subhead_03};
+`;
+
+export const UserIcon = styled.div`
+  height: 32px;
+`;
+
+export const Tag = styled.div`
+  color: ${({ theme }) => theme.colors.white};
+  display: flex;
+  align-items: center;
+  padding: 4px 14px;
+  height: 26px;
+  background-color: ${({ theme }) => theme.colors.secondary_800};
+  border-radius: 32px;
+  ${({ theme }) => theme.font.subhead_01};
+`;

--- a/src/m-pages/MobilePreParing/index.tsx
+++ b/src/m-pages/MobilePreParing/index.tsx
@@ -1,0 +1,26 @@
+import { LOGO } from '@/assets/icons/Logo';
+import { SYSTEM } from '@/assets/icons/System';
+import MobileLayout from '@/layouts/Mobile';
+import MobileHeader from '@/layouts/Mobile/components/MobileHeader';
+import MobileSideBar from '@/layouts/Mobile/components/MobileSideBar';
+
+import { useState } from 'react';
+
+const MobilePreParing = () => {
+  const [openSideBar, setOpenSideBar] = useState(false);
+
+  const sideBarHandler = () => {
+    setOpenSideBar((prev) => !prev);
+  };
+
+  return (
+    <MobileLayout>
+      <MobileHeader left={{ onClick: sideBarHandler, icon: SYSTEM.MENU }} title={LOGO.XS} hasAuth />
+
+      {SYSTEM.PREPARING}
+      {openSideBar && <MobileSideBar openSideBar={openSideBar} sideBarHandler={sideBarHandler} />}
+    </MobileLayout>
+  );
+};
+
+export default MobilePreParing;

--- a/src/pages/MemberManagement/index.tsx
+++ b/src/pages/MemberManagement/index.tsx
@@ -2,6 +2,7 @@ import { SYSTEM } from '@/assets/icons/System';
 import { USER } from '@/assets/icons/User';
 import MemberListItem from '@/components/MemberManagement/MemberListItem';
 import { GA } from '@/constants/GA';
+import useMemberManageMent from '@/hooks/Member/useMemberManageMent';
 import { useGroupDetail, useParticipantList } from '@/queries/Group';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
 import { copyInvitationLink } from '@/utils/copyInvitationLink';
@@ -9,19 +10,7 @@ import { useParams } from 'react-router-dom';
 import * as Style from './styles';
 
 const MemberManagement = () => {
-  const { groupId } = useParams();
-
-  const { data: participantList } = useParticipantList(Number(groupId));
-  const { data: myNickname } = useGetMyNikname(Number(groupId));
-  /**
-   * 혹시 이거 때문인가.. 데이터를 갈아 끼워줘도 recoil이 갈아끼워지지 않으니까..
-   * recoil로 관리를 하니까 사이드 이펙트가 발생하는구나
-   * 특히 optimistic update를 할 때, onMutate에서 낙관적인 데이터 넣어주고,
-   * 응답을 받고 나서는 제거해야 하는데 그럼 데이터를 넣을 때에도 setRecoilState를 해줘야 하고,
-   * 응답을 받고 나서도 onSettle에서 다시 한 번 업데이트를 해줘야 하니까 불편한게 많음
-   * => 서버 상태는 오직 tanstack-query 담당하게 하는 것이 맞음
-   */
-  const { data: group } = useGroupDetail(Number(groupId));
+  const { groupId, participantList, myNickname, group } = useMemberManageMent();
 
   return (
     <>

--- a/src/routes/MobileRouter.tsx
+++ b/src/routes/MobileRouter.tsx
@@ -1,3 +1,4 @@
+import MobileCalendar from '@/m-pages/MobileCalendar';
 import MobileCreateGroup from '@/m-pages/MobileCreateGroup';
 import MobileGroupHome from '@/m-pages/MobileGroupHome';
 import MobileHome from '@/m-pages/MobileHome';
@@ -15,6 +16,7 @@ const MobileRouter = () => {
         <Route path="/m-group/:groupId/home" element={<MobileGroupHome />} />
         <Route path="/m-group/:groupId/preparing" element={<MobilePreParing />} />
         <Route path="/m-group/:groupId/member" element={<MobileMemberManagement />} />
+        <Route path="/m-group/:groupId/calendar" element={<MobileCalendar />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/routes/MobileRouter.tsx
+++ b/src/routes/MobileRouter.tsx
@@ -1,6 +1,9 @@
 import MobileCreateGroup from '@/m-pages/MobileCreateGroup';
 import MobileGroupHome from '@/m-pages/MobileGroupHome';
 import MobileHome from '@/m-pages/MobileHome';
+import MobileMemberManagement from '@/m-pages/MobileMemberManagement';
+import MobilePreParing from '@/m-pages/MobilePreParing';
+import PreParing from '@/pages/PreParing';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 const MobileRouter = () => {
@@ -10,6 +13,8 @@ const MobileRouter = () => {
         <Route path="/m-home" element={<MobileHome />} />
         <Route path="/m-home/create-group" element={<MobileCreateGroup />} />
         <Route path="/m-group/:groupId/home" element={<MobileGroupHome />} />
+        <Route path="/m-group/:groupId/preparing" element={<MobilePreParing />} />
+        <Route path="/m-group/:groupId/member" element={<MobileMemberManagement />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -1,4 +1,4 @@
-export interface PayMentTpyeCountMap {
+export interface PayMentTypeCountMap {
   확인중: number;
   미납: number;
   완납: number;
@@ -9,7 +9,7 @@ export type EvnetId = {
 };
 
 export interface MonthStatus {
-  statusOfDay: { [date in number]: PayMentTpyeCountMap };
+  statusOfDay: { [date in number]: PayMentTypeCountMap };
 }
 
 export type Ground = '지각' | '결석' | '과제 안 함' | '기타';


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
캘린더 비지니스로직 분리 및  모바일 캘린더, 멤버관리 생성

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 캘린더 비지니스로직 분리
- 모바일 멤버관리 페이지 (스타일은 수정 필요)
- 모바일 캘린더 페이지 , UI 완성
![image](https://github.com/so-sim/front/assets/45344418/97b0673e-9b38-4eaf-8f69-d9f35a886c3c)
현재 캘린더 Layout은 종현님 작업 후 적용시키겠습니다!

캘린더의 height 또한 기기 뷰포트에 따라 전체로 채워줘야할지 고민이였습니다.
개인적으로 모바일 대응 경험이 없어 논의해보면 좋을 것 같습니다


<br />




## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
