### PR TITLE
Feat: 일괄 납부여부 변경 페이지 탈퇴회원 리스트 및 뱃지 추가 / AlarmInfo persist 적용 등 수정

### DIFF
--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/index.tsx
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/index.tsx
@@ -7,10 +7,12 @@ import CheckboxContainer from '@/components/@common/Checkbox';
 import DetailListCheckBox from '../../checkbox';
 import CheckStatusListWrapper from '@/components/@common/CheckStatusListWrapper';
 import { convertToPriceFormat } from '@/utils/convertFormat';
+import WithdrawBadge from '@/components/@common/WithdrawBadge';
 
 type Props = {
   myName: string;
   list?: SelectedEventInfo[];
+  isWithdrawalMember?: boolean;
   isChecked: (eventId: number) => boolean;
   setCheckDetailFine: (name: string, list: SelectedEventInfo[]) => void;
   pageFromAlarm?: boolean;
@@ -18,7 +20,7 @@ type Props = {
 
 // 팀원 수가 한명일 때로 style을 나누려고 했는데, Alarm에서 들어오는 페이지가 다르다고 첨언을 주셨다.
 
-const CheckedFineList = ({ myName, list, setCheckDetailFine, isChecked, pageFromAlarm = false }: Props) => {
+const CheckedFineList = ({ myName, list, isWithdrawalMember, setCheckDetailFine, isChecked, pageFromAlarm = false }: Props) => {
   const [toggle, setToggle] = useState(false);
 
   const TotalAmount = list?.reduce((prev, current) => prev + current.amount, 0);
@@ -42,7 +44,9 @@ const CheckedFineList = ({ myName, list, setCheckDetailFine, isChecked, pageFrom
               <CheckboxContainer.Checkbox as={DetailListCheckBox} />
             </CheckboxContainer>
 
-            <Style.ItemTitle>{myName}</Style.ItemTitle>
+            <Style.ItemTitle>
+              {myName} {isWithdrawalMember && <WithdrawBadge />}
+            </Style.ItemTitle>
             <Style.ItemAmount isOpen={toggle}>
               {convertToPriceFormat(TotalAmount!)}
               <Style.Monetary_Unit>원</Style.Monetary_Unit>

--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/index.tsx
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/index.tsx
@@ -8,6 +8,7 @@ import DetailListCheckBox from '../../checkbox';
 import CheckStatusListWrapper from '@/components/@common/CheckStatusListWrapper';
 import { convertToPriceFormat } from '@/utils/convertFormat';
 import WithdrawBadge from '@/components/@common/WithdrawBadge';
+import { USER } from '@/assets/icons/User';
 
 type Props = {
   myName: string;
@@ -45,6 +46,7 @@ const CheckedFineList = ({ myName, list, isWithdrawalMember, setCheckDetailFine,
             </CheckboxContainer>
 
             <Style.ItemTitle>
+              <Style.UserIconWrapper>{USER.PERSON_24}</Style.UserIconWrapper>
               {myName} {isWithdrawalMember && <WithdrawBadge />}
             </Style.ItemTitle>
             <Style.ItemAmount isOpen={toggle}>

--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/styles.ts
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/styles.ts
@@ -17,7 +17,10 @@ export const ItemWrapper = styled.div`
 `;
 
 export const ItemTitle = styled.p`
-  ${({ theme }) => theme.font.body_02}
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  ${({ theme }) => theme.font.body_02};
 `;
 
 export const ItemAmount = styled.p<{ isOpen?: boolean }>`

--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/styles.ts
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/CheckedFineList/styles.ts
@@ -16,6 +16,11 @@ export const ItemWrapper = styled.div`
   padding-right: 34px;
 `;
 
+export const UserIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
 export const ItemTitle = styled.p`
   display: flex;
   align-items: center;

--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/index.tsx
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/index.tsx
@@ -132,6 +132,7 @@ const AlarmRequest_PaymentUpdate = ({ checkDetailFine }: Props) => {
   }, [checkDetailFine]);
 
   useEffect(() => {
+    setSelectedFine(initialSelectData);
     return () => {
       setSideModal(initialSideModalState);
     };

--- a/src/components/DetailFine/AlarmRequest_PaymentUpdate/index.tsx
+++ b/src/components/DetailFine/AlarmRequest_PaymentUpdate/index.tsx
@@ -105,6 +105,8 @@ const AlarmRequest_PaymentUpdate = ({ checkDetailFine }: Props) => {
 
   const [sideModal, setSideModal] = useRecoilState(sideModalState);
 
+  const { selectedFine, setSelectedFine } = useSelectedContext('userDetails');
+
   const [_, setIsOpen] = useRecoilState(detailFineState);
 
   const originalCheckListValue = Object.values(checkDetailFine);
@@ -115,6 +117,8 @@ const AlarmRequest_PaymentUpdate = ({ checkDetailFine }: Props) => {
   const detailFineList = Object.values(checkList);
 
   const currentSituation = React.useMemo(() => Object.values(checkDetailFine)[0]?.situation, []);
+
+  const { participantListWithWithdrawnMembers, isWithdrawal } = useWithdrawalParticipantList(Number(groupId));
 
   //disabled 되어야하는 List를 가져오는 hook (일단 임시 주석)  추가하려면 '납부완료'상태에만 disabled를 하는 코드를 추가해야함
   // const { disabledEventIdList, isDisabledItem } = useDisabledList(Number(groupId), originalCheckListEventId, currentSituation);
@@ -233,8 +237,6 @@ const AlarmRequest_PaymentUpdate = ({ checkDetailFine }: Props) => {
 
   const getSingleNickName = originalCheckListValue[0].nickname;
 
-  const { isWithdrawal } = useWithdrawalParticipantList(Number(groupId));
-
   // 해당 로직을 ItemList에서 toggle이 실행되었을 때 해주어도 좋을 것 같다.
 
   const max_Date = (sortedtList: SelectedEventInfo[]) => sortedtList.at(-1)?.date;
@@ -276,10 +278,11 @@ const AlarmRequest_PaymentUpdate = ({ checkDetailFine }: Props) => {
           {isSingleList(originalCheckListValue) ? (
             <SingleCheckedFineList checkDetailFine={originalCheckListValue} setCheckDetailFine={setToggleCheckList} isChecked={isChecked} />
           ) : (
-            participantList?.map((nickName) => (
+            participantListWithWithdrawnMembers?.map((nickName) => (
               <CheckedFineList
                 key={nickName}
                 myName={nickName as string}
+                isWithdrawalMember={isWithdrawal(nickName)}
                 list={participantSituation_List(nickName as string, sortedtList)}
                 isChecked={isChecked}
                 setCheckDetailFine={setToggleCheckListByName}

--- a/src/components/DetailFine/DetailList/index.tsx
+++ b/src/components/DetailFine/DetailList/index.tsx
@@ -22,7 +22,7 @@ import { useParams } from 'react-router-dom';
 import WithdrawBadge from '@/components/@common/WithdrawBadge';
 import { useGroupDetail } from '@/queries/Group';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
-
+import { sideModalState } from '@/store/sideModalState';
 
 type Props = {
   details?: SelectedEventInfo[];
@@ -34,6 +34,8 @@ const DetailList = ({ detailFilter, details }: Props) => {
   const [calendarState, setCalendarState] = useRecoilState(dateState);
 
   const [openButtonListId, setOpenButtonListId] = useState(0);
+
+  const [sideModal, setSideModal] = useRecoilState(sideModalState);
 
   const { selectedFine, setSelectedFine } = useSelectedContext('userDetails');
   const { mutate: mutateRequestNotification } = useRequestNotification();
@@ -72,6 +74,11 @@ const DetailList = ({ detailFilter, details }: Props) => {
     });
   };
 
+  const handleToggleCheckbox = (event: React.MouseEvent<HTMLInputElement>, detail: SelectedEventInfo) => {
+    event.stopPropagation();
+    setToggleCheckList(detail);
+  };
+
   useEffect(() => {
     const closeCircleButtonList = () => {
       setOpenButtonListId(0);
@@ -84,7 +91,9 @@ const DetailList = ({ detailFilter, details }: Props) => {
   }, []);
 
   useEffect(() => {
-    setInitCheckDetailFine();
+    if (sideModal.isModal !== true) {
+      setInitCheckDetailFine();
+    }
   }, [openButtonListId, selectedFine]);
 
   useEffect(() => {
@@ -105,17 +114,11 @@ const DetailList = ({ detailFilter, details }: Props) => {
         const enableNotification = true;
         return (
           <Style.TableRow isAdmin={isAdmin} key={i} isSelected={selectedFine.eventId === eventId} onClick={() => handleUserDetailModal(detail)}>
-            <Style.CheckboxWrapper
-              onClick={(e) => {
-                e.stopPropagation();
-                setToggleCheckList(detail);
-              }}
-            >
-              <CheckboxContainer id={String(eventId)} isChecked={isChecked(eventId)} onChange={(event: React.MouseEvent<HTMLInputElement>) => setToggleCheckList(detail)}>
-                <CheckboxContainer.Checkbox as={DetailListCheckBox} />
-                {/*    이 부분 props를 자연스럽게 넘겨주려면 이 방법 밖에?? function으로 넘겨주는 방법도 있긴한데,  이거는 rest props 안넘어옴 */}
-              </CheckboxContainer>
-            </Style.CheckboxWrapper>
+            <CheckboxContainer id={String(eventId)} isChecked={isChecked(eventId)} onChange={(event: React.MouseEvent<HTMLInputElement>) => handleToggleCheckbox(event, detail)}>
+              <CheckboxContainer.Checkbox as={DetailListCheckBox} />
+              {/*    이 부분 props를 자연스럽게 넘겨주려면 이 방법 밖에?? function으로 넘겨주는 방법도 있긴한데,  이거는 rest props 안넘어옴 */}
+            </CheckboxContainer>
+
             <Style.Element hasEllipsis={false}>{covertDateForView(date.slice(2))}</Style.Element>
             <DropDownWrapper openButtonListId={openButtonListId} detail={detail} setOpenButtonListId={setOpenButtonListId} />
             <Style.FlexElement hasEllipsis>

--- a/src/m-pages/MobileFineBookDetail/index.tsx
+++ b/src/m-pages/MobileFineBookDetail/index.tsx
@@ -17,12 +17,14 @@ import { useGroupDetail } from '@/queries/Group';
 import { useGetMyNikname } from '@/queries/Group/useGetMyNickname';
 import { useWithdrawalParticipantList } from '@/queries/Group/useWithdrawalParticipantList';
 import { useRequestNotification } from '@/queries/Notification/useRequestNotifaction';
+import { detailFineState } from '@/store/detailFineState';
 import { Situation } from '@/types/event';
 import { changeNumberToMoney } from '@/utils/changeNumberToMoney';
 import { covertDateForView } from '@/utils/convertFormat';
 import { pushDataLayer } from '@/utils/pushDataLayer';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import * as Style from './styles';
 
@@ -49,6 +51,8 @@ const MobileFineBookDetail = () => {
 
   const { data, isLoading } = useGetOneOfDetail(Number(fineBookDetailId));
 
+  const [isOpen, setIsOpen] = useRecoilState(detailFineState);
+
   const { eventId, date, situation, nickname, amount, memo, ground } = data?.content || {
     eventId: 1,
     date: 'loading',
@@ -65,6 +69,7 @@ const MobileFineBookDetail = () => {
   const isOwn = nickname === myNickname?.content.nickname;
 
   const goBack = () => {
+    setIsOpen(true);
     navigate(-1);
   };
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -4,10 +4,12 @@ import * as Style from './styles';
 import useRecentlyVisitedGroup from '@/hooks/useRecentlyVisitedGroup';
 import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 import { getAccessToken } from '@/utils/acceessToken';
+import { useQueryClient } from '@tanstack/react-query';
 
 const Home = () => {
   const { isExist, navigateToSavedGroup } = useRecentlyVisitedGroup();
 
+  const queryClient = useQueryClient();
   useEffect(() => {
     const EventSource = EventSourcePolyfill || NativeEventSource;
     const SSE = new EventSource(`${process.env.REACT_APP_SERVER_URL}/api/subscribe`, {
@@ -24,6 +26,7 @@ const Home = () => {
 
     SSE.addEventListener('notification', (e) => {
       console.log('notification: ', e);
+      queryClient.invalidateQueries(['notificationCount']);
     });
   }, []);
 

--- a/src/queries/Group/useWithdrawalParticipantList.ts
+++ b/src/queries/Group/useWithdrawalParticipantList.ts
@@ -12,7 +12,10 @@ export const useWithdrawalParticipantList = (groupId: number | undefined) => {
     return withdrawalParticipants?.includes(nickname);
   };
 
+  const participantListWithWithdrawnMembers = participantList?.content.nicknameList.map((item) => item.nickname);
+
   return {
+    participantListWithWithdrawnMembers,
     withdrawalParticipants,
     isWithdrawal,
   };

--- a/src/store/alarmInfoState.ts
+++ b/src/store/alarmInfoState.ts
@@ -1,5 +1,11 @@
 import { SituationStatus } from '@/types/notification';
+import { isMobile } from 'react-device-detect';
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist({
+  storage: localStorage,
+});
 
 export type AlarmInfoType = {
   alarmEventIdList: number[];
@@ -20,4 +26,5 @@ export const initAlarmInfoState = {
 export const alarmInfoState = atom<AlarmInfoType>({
   key: 'alarmEventIdListState',
   default: initAlarmInfoState,
+  effects_UNSTABLE: isMobile ? [persistAtom] : [],
 });


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 일괄 납부여부 변경 여러 명 페이지일 때  탈퇴회원도 리스트에 포함되도록 추가
- 납부여부 변경 및 요청 페이지 탈퇴회원 뱃지 추가
- [모바일 알람 새로고침 대응을 위해 persist 적용](https://github.com/so-sim/front/commit/bf94a87f58b9b1c726273d8e665e20c389f2500a)
- [Mobile 자세히보기에서 뒤로가기 시 DetailList 팝업 열려있도록 수정](https://github.com/so-sim/front/commit/d03f54e83f5fc75624e10ec3e37441b1bc66e619)
- 납부여부 변경 및 요청 페이지 진입 시 -> 자세히보기 페이지는 닫히도록 수정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
